### PR TITLE
feat(perf): make QPS and Burst configurable

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,6 +42,8 @@ var (
 	informerRelist    = flag.Duration("cache-flush-interval", 30*time.Minute, "How often to flush local caches and relist objects from the API server")
 	debugAddr         = flag.String("debug-addr", ":9999", "The address to bind the debug http endpoints")
 	clientConfigPath  = flag.String("client-config-path", "", "Path to kubeconfig file (same format as used by kubectl); if not specified, use in-cluster config")
+	clientGoQPS       = flag.Float64("client-go-qps", 5, "Number of queries per second client-go is allowed to make (default 5)")
+	clientGoBurst     = flag.Int("client-go-burst", 10, "Allowed burst queries for client-go (default 10)")
 )
 
 func main() {
@@ -65,8 +67,8 @@ func main() {
 		glog.Fatal(err)
 	}
 
-	config.QPS = 100
-	config.Burst = 300
+	config.QPS = float32(*clientGoQPS)
+	config.Burst = *clientGoBurst
 
 	stopServer, err := server.Start(config, *discoveryInterval, *informerRelist)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -60,9 +60,13 @@ func main() {
 		glog.Info("No kubeconfig file specified; trying in-cluster auto-config...")
 		config, err = rest.InClusterConfig()
 	}
+
 	if err != nil {
 		glog.Fatal(err)
 	}
+
+	config.QPS = 100
+	config.Burst = 300
 
 	stopServer, err := server.Start(config, *discoveryInterval, *informerRelist)
 	if err != nil {


### PR DESCRIPTION
Currently, meta controller does not explicitly set  QPS and Burst when it creates its Kube client. The default QPS is 5, this is a bottleneck on deployments where meta controller is serving multiple operators. 