### PR TITLE
chore(api): Update CRD api versions to v1

### DIFF
--- a/apis/metacontroller/v1alpha1/types.go
+++ b/apis/metacontroller/v1alpha1/types.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// +groupName=metacontroller.k8s.io
 package v1alpha1
 
 import (
@@ -26,6 +27,8 @@ import (
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:path=compositecontrollers,scope=Cluster,shortName=cc;cctl
 type CompositeController struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
@@ -130,6 +133,9 @@ type CompositeControllerList struct {
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:path=controllerrevisions,scope=Namespaced
+
 type ControllerRevision struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
@@ -156,7 +162,8 @@ type ControllerRevisionList struct {
 // +genclient:noStatus
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:path=decoratorcontrollers,scope=Cluster,shortName=dec;decorators
 type DecoratorController struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`

--- a/hack/get-kube-binaries.sh
+++ b/hack/get-kube-binaries.sh
@@ -10,7 +10,7 @@ set -u
 # The integration test framework expects these binaries to be found in the PATH.
 
 # This is the kube-apiserver version to test against.
-KUBE_VERSION="${KUBE_VERSION:-v1.11.3}"
+KUBE_VERSION="${KUBE_VERSION:-v1.18.8}"
 KUBERNETES_RELEASE_URL="${KUBERNETES_RELEASE_URL:-https://dl.k8s.io}"
 
 # This should be the etcd version downloaded by kubernetes/hack/lib/etcd.sh

--- a/manifests/metacontroller.yaml
+++ b/manifests/metacontroller.yaml
@@ -1,47 +1,517 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: compositecontrollers.metacontroller.k8s.io
+  annotations:
+    "api-approved.kubernetes.io": "unapproved, request not yet submitted"
 spec:
   group: metacontroller.k8s.io
-  version: v1alpha1
-  scope: Cluster
   names:
-    plural: compositecontrollers
-    singular: compositecontroller
     kind: CompositeController
+    listKind: CompositeControllerList
+    plural: compositecontrollers
     shortNames:
-    - cc
-    - cctl
+      - cc
+      - cctl
+    singular: compositecontroller
+  scope: Cluster
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                childResources:
+                  items:
+                    properties:
+                      apiVersion:
+                        type: string
+                      resource:
+                        type: string
+                      updateStrategy:
+                        properties:
+                          method:
+                            type: string
+                          statusChecks:
+                            properties:
+                              conditions:
+                                items:
+                                  properties:
+                                    reason:
+                                      type: string
+                                    status:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                    required:
+                      - apiVersion
+                      - resource
+                    type: object
+                  type: array
+                generateSelector:
+                  type: boolean
+                hooks:
+                  properties:
+                    finalize:
+                      properties:
+                        webhook:
+                          properties:
+                            path:
+                              type: string
+                            service:
+                              properties:
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                                port:
+                                  format: int32
+                                  type: integer
+                                protocol:
+                                  type: string
+                              required:
+                                - name
+                                - namespace
+                              type: object
+                            timeout:
+                              type: string
+                            url:
+                              type: string
+                          type: object
+                      type: object
+                    postUpdateChild:
+                      properties:
+                        webhook:
+                          properties:
+                            path:
+                              type: string
+                            service:
+                              properties:
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                                port:
+                                  format: int32
+                                  type: integer
+                                protocol:
+                                  type: string
+                              required:
+                                - name
+                                - namespace
+                              type: object
+                            timeout:
+                              type: string
+                            url:
+                              type: string
+                          type: object
+                      type: object
+                    preUpdateChild:
+                      properties:
+                        webhook:
+                          properties:
+                            path:
+                              type: string
+                            service:
+                              properties:
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                                port:
+                                  format: int32
+                                  type: integer
+                                protocol:
+                                  type: string
+                              required:
+                                - name
+                                - namespace
+                              type: object
+                            timeout:
+                              type: string
+                            url:
+                              type: string
+                          type: object
+                      type: object
+                    sync:
+                      properties:
+                        webhook:
+                          properties:
+                            path:
+                              type: string
+                            service:
+                              properties:
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                                port:
+                                  format: int32
+                                  type: integer
+                                protocol:
+                                  type: string
+                              required:
+                                - name
+                                - namespace
+                              type: object
+                            timeout:
+                              type: string
+                            url:
+                              type: string
+                          type: object
+                      type: object
+                  type: object
+                parentResource:
+                  properties:
+                    apiVersion:
+                      type: string
+                    resource:
+                      type: string
+                    revisionHistory:
+                      properties:
+                        fieldPaths:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                  required:
+                    - apiVersion
+                    - resource
+                  type: object
+                resyncPeriodSeconds:
+                  format: int32
+                  type: integer
+              required:
+                - parentResource
+              type: object
+            status:
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    "api-approved.kubernetes.io": "unapproved, request not yet submitted"
   name: decoratorcontrollers.metacontroller.k8s.io
 spec:
   group: metacontroller.k8s.io
-  version: v1alpha1
-  scope: Cluster
   names:
-    plural: decoratorcontrollers
-    singular: decoratorcontroller
     kind: DecoratorController
+    listKind: DecoratorControllerList
+    plural: decoratorcontrollers
     shortNames:
-    - dec
-    - decorators
+      - dec
+      - decorators
+    singular: decoratorcontroller
+  scope: Cluster
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                attachments:
+                  items:
+                    properties:
+                      apiVersion:
+                        type: string
+                      resource:
+                        type: string
+                      updateStrategy:
+                        properties:
+                          method:
+                            type: string
+                        type: object
+                    required:
+                      - apiVersion
+                      - resource
+                    type: object
+                  type: array
+                hooks:
+                  properties:
+                    finalize:
+                      properties:
+                        webhook:
+                          properties:
+                            path:
+                              type: string
+                            service:
+                              properties:
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                                port:
+                                  format: int32
+                                  type: integer
+                                protocol:
+                                  type: string
+                              required:
+                                - name
+                                - namespace
+                              type: object
+                            timeout:
+                              type: string
+                            url:
+                              type: string
+                          type: object
+                      type: object
+                    sync:
+                      properties:
+                        webhook:
+                          properties:
+                            path:
+                              type: string
+                            service:
+                              properties:
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                                port:
+                                  format: int32
+                                  type: integer
+                                protocol:
+                                  type: string
+                              required:
+                                - name
+                                - namespace
+                              type: object
+                            timeout:
+                              type: string
+                            url:
+                              type: string
+                          type: object
+                      type: object
+                  type: object
+                resources:
+                  items:
+                    properties:
+                      annotationSelector:
+                        properties:
+                          matchAnnotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          matchExpressions:
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that relates
+                                the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty. This
+                                    array is replaced during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                        type: object
+                      apiVersion:
+                        type: string
+                      labelSelector:
+                        description: A label selector is a label query over a set of
+                          resources. The result of matchLabels and matchExpressions
+                          are ANDed. An empty label selector matches all objects. A
+                          null label selector matches no objects.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that relates
+                                the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty. This
+                                    array is replaced during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      resource:
+                        type: string
+                    required:
+                      - apiVersion
+                      - resource
+                    type: object
+                  type: array
+                resyncPeriodSeconds:
+                  format: int32
+                  type: integer
+              required:
+                - resources
+              type: object
+            status:
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    "api-approved.kubernetes.io": "unapproved, request not yet submitted"
   name: controllerrevisions.metacontroller.k8s.io
 spec:
   group: metacontroller.k8s.io
-  version: v1alpha1
-  scope: Namespaced
   names:
+    kind: ControllerRevision
+    listKind: ControllerRevisionList
     plural: controllerrevisions
     singular: controllerrevision
-    kind: ControllerRevision
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+              type: string
+            children:
+              items:
+                properties:
+                  apiGroup:
+                    type: string
+                  kind:
+                    type: string
+                  names:
+                    items:
+                      type: string
+                    type: array
+                required:
+                  - apiGroup
+                  - kind
+                  - names
+                type: object
+              type: array
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            parentPatch:
+              type: object
+          required:
+            - metadata
+            - parentPatch
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
 apiVersion: apps/v1
 kind: StatefulSet


### PR DESCRIPTION
This PR uses [controller-gen](https://github.com/kubernetes-sigs/controller-tools/tree/master/cmd/controller-gen) in conjunction with [kubebuilder annotations](https://book.kubebuilder.io/reference/markers/crd.html) to update CRD versions to `apiextensions.k8s.io/v1`.

The CRDs can be generated using: `controller-gen crd paths=./apis/metacontroller/... output:stdout > crds.yaml`

