### PR TITLE
chore(api): Update CRD api versions to v1

### DIFF
--- a/apis/metacontroller/v1alpha1/types.go
+++ b/apis/metacontroller/v1alpha1/types.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// +groupName=metacontroller.k8s.io
 package v1alpha1
 
 import (
@@ -26,6 +27,8 @@ import (
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:path=compositecontrollers,scope=Cluster,shortName=cc;cctl
 type CompositeController struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
@@ -130,6 +133,8 @@ type CompositeControllerList struct {
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:path=controllerrevisions,scope=Namespaced
 type ControllerRevision struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
@@ -156,7 +161,8 @@ type ControllerRevisionList struct {
 // +genclient:noStatus
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:path=decoratorcontrollers,scope=Cluster,shortName=dec;decorators
 type DecoratorController struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`

--- a/examples/bluegreen/bluegreen-controller.yaml
+++ b/examples/bluegreen/bluegreen-controller.yaml
@@ -1,10 +1,9 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: bluegreendeployments.ctl.enisoc.com
 spec:
   group: ctl.enisoc.com
-  version: v1
   scope: Namespaced
   names:
     plural: bluegreendeployments
@@ -12,8 +11,15 @@ spec:
     kind: BlueGreenDeployment
     shortNames:
     - bgd
-  subresources:
-    status: {}
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        x-kubernetes-preserve-unknown-fields: true
+    subresources:
+      status: {}
 ---
 apiVersion: metacontroller.k8s.io/v1alpha1
 kind: CompositeController
@@ -28,7 +34,7 @@ spec:
     resource: services
     updateStrategy:
       method: InPlace
-  - apiVersion: extensions/v1beta1
+  - apiVersion: apps/v1
     resource: replicasets
     updateStrategy:
       method: InPlace

--- a/examples/bluegreen/sync.js
+++ b/examples/bluegreen/sync.js
@@ -43,7 +43,7 @@ var podTemplateEqual = function (bgd, rs) {
 
 var newReplicaSet = function (bgd, color, replicas, template) {
   let rs = {
-    apiVersion: 'extensions/v1beta1',
+    apiVersion: 'apps/v1',
     kind: 'ReplicaSet',
     metadata: {
       name: `${bgd.metadata.name}-${color}`,
@@ -81,7 +81,7 @@ module.exports = async function (context) {
 
   try {
     let bgd = observed.parent;
-    let observedRS = observed.children['ReplicaSet.extensions/v1beta1'];
+    let observedRS = observed.children['ReplicaSet.apps/v1'];
 
     // Compute status from observed state.
     let service = observed.children['Service.v1'][bgd.spec.service.metadata.name];

--- a/examples/catset/catset-controller.yaml
+++ b/examples/catset/catset-controller.yaml
@@ -1,10 +1,9 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: catsets.ctl.enisoc.com
 spec:
   group: ctl.enisoc.com
-  version: v1
   scope: Namespaced
   names:
     plural: catsets
@@ -12,8 +11,15 @@ spec:
     kind: CatSet
     shortNames:
     - cs
-  subresources:
-    status: {}
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        x-kubernetes-preserve-unknown-fields: true
+    subresources:
+      status: {}
 ---
 apiVersion: metacontroller.k8s.io/v1alpha1
 kind: CompositeController

--- a/examples/crd-roles/crd-role-controller.yaml
+++ b/examples/crd-roles/crd-role-controller.yaml
@@ -5,7 +5,7 @@ metadata:
   name: crd-role-controller
 spec:
   resources:
-  - apiVersion: apiextensions.k8s.io/v1beta1
+  - apiVersion: apiextensions.k8s.io/v1
     resource: customresourcedefinitions
     annotationSelector:
       matchExpressions:

--- a/examples/crd-roles/my-crd.yaml
+++ b/examples/crd-roles/my-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name:  my-tests.ctl.rlg.io
@@ -6,9 +6,17 @@ metadata:
     enable-default-roles: "yes"
 spec:
   group: ctl.rlg.io
-  version: v1
   scope: Cluster
   names:
     plural: my-tests
     singular: my-test
     kind: MyTest
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        x-kubernetes-preserve-unknown-fields: true
+    subresources:
+      status: {}

--- a/examples/daemonjob/daemonjob-controller.yaml
+++ b/examples/daemonjob/daemonjob-controller.yaml
@@ -1,18 +1,24 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: daemonjobs.ctl.example.com
 spec:
   group: ctl.example.com
-  version: v1
   scope: Namespaced
   names:
     plural: daemonjobs
     singular: daemonjob
     kind: DaemonJob
     shortNames: ["dj"]
-  subresources:
-    status: {}
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        x-kubernetes-preserve-unknown-fields: true
+    subresources:
+      status: {}
 ---
 apiVersion: metacontroller.k8s.io/v1alpha1
 kind: CompositeController

--- a/examples/go/thing-controller.yaml
+++ b/examples/go/thing-controller.yaml
@@ -1,15 +1,23 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: things.ctl.enisoc.com
 spec:
   group: ctl.enisoc.com
-  version: v1
   scope: Namespaced
   names:
     plural: things
     singular: thing
     kind: Thing
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        x-kubernetes-preserve-unknown-fields: true
+    subresources:
+      status: {}
 ---
 apiVersion: metacontroller.k8s.io/v1alpha1
 kind: CompositeController

--- a/examples/indexedjob/indexedjob-controller.yaml
+++ b/examples/indexedjob/indexedjob-controller.yaml
@@ -1,18 +1,24 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: indexedjobs.ctl.enisoc.com
 spec:
   group: ctl.enisoc.com
-  version: v1
   scope: Namespaced
   names:
     plural: indexedjobs
     singular: indexedjob
     kind: IndexedJob
     shortNames: ["ij", "idxj"]
-  subresources:
-    status: {}
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        x-kubernetes-preserve-unknown-fields: true
+    subresources:
+      status: {}
 ---
 apiVersion: metacontroller.k8s.io/v1alpha1
 kind: CompositeController

--- a/examples/status/noop-controller.yaml
+++ b/examples/status/noop-controller.yaml
@@ -1,17 +1,26 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    "api-approved.kubernetes.io": "unapproved, request not yet submitted"
   name: noops.metacontroller.k8s.io
 spec:
   group: metacontroller.k8s.io
-  version: v1
   scope: Namespaced
   names:
     plural: noops
     singular: noop
     kind: Noop
-  subresources:
-    status: {}
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        x-kubernetes-preserve-unknown-fields: true
+    subresources:
+      status: {}
+
 ---
 apiVersion: metacontroller.k8s.io/v1alpha1
 kind: DecoratorController
@@ -52,7 +61,7 @@ spec:
       - name: hooks
         configMap:
           name: noop-controller
-     
+
 ---
 apiVersion: v1
 kind: Service

--- a/manifests/metacontroller.yaml
+++ b/manifests/metacontroller.yaml
@@ -1,47 +1,517 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: compositecontrollers.metacontroller.k8s.io
+  annotations:
+    "api-approved.kubernetes.io": "unapproved, request not yet submitted"
 spec:
   group: metacontroller.k8s.io
-  version: v1alpha1
-  scope: Cluster
   names:
-    plural: compositecontrollers
-    singular: compositecontroller
     kind: CompositeController
+    listKind: CompositeControllerList
+    plural: compositecontrollers
     shortNames:
-    - cc
-    - cctl
+      - cc
+      - cctl
+    singular: compositecontroller
+  scope: Cluster
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                childResources:
+                  items:
+                    properties:
+                      apiVersion:
+                        type: string
+                      resource:
+                        type: string
+                      updateStrategy:
+                        properties:
+                          method:
+                            type: string
+                          statusChecks:
+                            properties:
+                              conditions:
+                                items:
+                                  properties:
+                                    reason:
+                                      type: string
+                                    status:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                    required:
+                      - apiVersion
+                      - resource
+                    type: object
+                  type: array
+                generateSelector:
+                  type: boolean
+                hooks:
+                  properties:
+                    finalize:
+                      properties:
+                        webhook:
+                          properties:
+                            path:
+                              type: string
+                            service:
+                              properties:
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                                port:
+                                  format: int32
+                                  type: integer
+                                protocol:
+                                  type: string
+                              required:
+                                - name
+                                - namespace
+                              type: object
+                            timeout:
+                              type: string
+                            url:
+                              type: string
+                          type: object
+                      type: object
+                    postUpdateChild:
+                      properties:
+                        webhook:
+                          properties:
+                            path:
+                              type: string
+                            service:
+                              properties:
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                                port:
+                                  format: int32
+                                  type: integer
+                                protocol:
+                                  type: string
+                              required:
+                                - name
+                                - namespace
+                              type: object
+                            timeout:
+                              type: string
+                            url:
+                              type: string
+                          type: object
+                      type: object
+                    preUpdateChild:
+                      properties:
+                        webhook:
+                          properties:
+                            path:
+                              type: string
+                            service:
+                              properties:
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                                port:
+                                  format: int32
+                                  type: integer
+                                protocol:
+                                  type: string
+                              required:
+                                - name
+                                - namespace
+                              type: object
+                            timeout:
+                              type: string
+                            url:
+                              type: string
+                          type: object
+                      type: object
+                    sync:
+                      properties:
+                        webhook:
+                          properties:
+                            path:
+                              type: string
+                            service:
+                              properties:
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                                port:
+                                  format: int32
+                                  type: integer
+                                protocol:
+                                  type: string
+                              required:
+                                - name
+                                - namespace
+                              type: object
+                            timeout:
+                              type: string
+                            url:
+                              type: string
+                          type: object
+                      type: object
+                  type: object
+                parentResource:
+                  properties:
+                    apiVersion:
+                      type: string
+                    resource:
+                      type: string
+                    revisionHistory:
+                      properties:
+                        fieldPaths:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                  required:
+                    - apiVersion
+                    - resource
+                  type: object
+                resyncPeriodSeconds:
+                  format: int32
+                  type: integer
+              required:
+                - parentResource
+              type: object
+            status:
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    "api-approved.kubernetes.io": "unapproved, request not yet submitted"
   name: decoratorcontrollers.metacontroller.k8s.io
 spec:
   group: metacontroller.k8s.io
-  version: v1alpha1
-  scope: Cluster
   names:
-    plural: decoratorcontrollers
-    singular: decoratorcontroller
     kind: DecoratorController
+    listKind: DecoratorControllerList
+    plural: decoratorcontrollers
     shortNames:
-    - dec
-    - decorators
+      - dec
+      - decorators
+    singular: decoratorcontroller
+  scope: Cluster
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                attachments:
+                  items:
+                    properties:
+                      apiVersion:
+                        type: string
+                      resource:
+                        type: string
+                      updateStrategy:
+                        properties:
+                          method:
+                            type: string
+                        type: object
+                    required:
+                      - apiVersion
+                      - resource
+                    type: object
+                  type: array
+                hooks:
+                  properties:
+                    finalize:
+                      properties:
+                        webhook:
+                          properties:
+                            path:
+                              type: string
+                            service:
+                              properties:
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                                port:
+                                  format: int32
+                                  type: integer
+                                protocol:
+                                  type: string
+                              required:
+                                - name
+                                - namespace
+                              type: object
+                            timeout:
+                              type: string
+                            url:
+                              type: string
+                          type: object
+                      type: object
+                    sync:
+                      properties:
+                        webhook:
+                          properties:
+                            path:
+                              type: string
+                            service:
+                              properties:
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                                port:
+                                  format: int32
+                                  type: integer
+                                protocol:
+                                  type: string
+                              required:
+                                - name
+                                - namespace
+                              type: object
+                            timeout:
+                              type: string
+                            url:
+                              type: string
+                          type: object
+                      type: object
+                  type: object
+                resources:
+                  items:
+                    properties:
+                      annotationSelector:
+                        properties:
+                          matchAnnotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          matchExpressions:
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that relates
+                                the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty. This
+                                    array is replaced during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                        type: object
+                      apiVersion:
+                        type: string
+                      labelSelector:
+                        description: A label selector is a label query over a set of
+                          resources. The result of matchLabels and matchExpressions
+                          are ANDed. An empty label selector matches all objects. A
+                          null label selector matches no objects.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that relates
+                                the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty. This
+                                    array is replaced during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      resource:
+                        type: string
+                    required:
+                      - apiVersion
+                      - resource
+                    type: object
+                  type: array
+                resyncPeriodSeconds:
+                  format: int32
+                  type: integer
+              required:
+                - resources
+              type: object
+            status:
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    "api-approved.kubernetes.io": "unapproved, request not yet submitted"
   name: controllerrevisions.metacontroller.k8s.io
 spec:
   group: metacontroller.k8s.io
-  version: v1alpha1
-  scope: Namespaced
   names:
+    kind: ControllerRevision
+    listKind: ControllerRevisionList
     plural: controllerrevisions
     singular: controllerrevision
-    kind: ControllerRevision
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+              type: string
+            children:
+              items:
+                properties:
+                  apiGroup:
+                    type: string
+                  kind:
+                    type: string
+                  names:
+                    items:
+                      type: string
+                    type: array
+                required:
+                  - apiGroup
+                  - kind
+                  - names
+                type: object
+              type: array
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            parentPatch:
+              type: object
+          required:
+            - metadata
+            - parentPatch
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/test/integration/composite/composite_test.go
+++ b/test/integration/composite/composite_test.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
-	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/test/integration/decorator/decorator_test.go
+++ b/test/integration/decorator/decorator_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/json"

--- a/test/integration/framework/fixture.go
+++ b/test/integration/framework/fixture.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
-	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -43,7 +43,7 @@ type Fixture struct {
 
 	dynamic        *dynamicclientset.Clientset
 	kubernetes     kubernetes.Interface
-	apiextensions  apiextensionsclient.ApiextensionsV1beta1Interface
+	apiextensions  apiextensionsclient.ApiextensionsV1Interface
 	metacontroller mcclientset.Interface
 }
 

--- a/test/integration/framework/metacontroller.go
+++ b/test/integration/framework/metacontroller.go
@@ -17,7 +17,7 @@ limitations under the License.
 package framework
 
 import (
-	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	pointer "metacontroller.io/third_party/kubernetes"
 


### PR DESCRIPTION
This PR uses [controller-gen](https://github.com/kubernetes-sigs/controller-tools/tree/master/cmd/controller-gen) in conjunction with [kubebuilder annotations](https://book.kubebuilder.io/reference/markers/crd.html) to update CRD versions to `apiextensions.k8s.io/v1`.

The CRDs can be generated using: `controller-gen crd paths=./apis/metacontroller/... output:stdout > crds.yaml`

