### PR TITLE
chore(#25): Add release assets and update manifests on release

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -118,10 +118,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 13.8.0
       - name: Install dependencies
         run: npm install ci
       - name: Release
         env:
           GH_TOKEN: ${{ secrets.PAT }}
-        run: npx semantic-release
+        run: |
+          npm install @semantic-release/git @semantic-release/changelog @google/semantic-release-replace-plugin -D
+          npx semantic-release

--- a/release.config.js
+++ b/release.config.js
@@ -3,5 +3,44 @@ module.exports = {
   "plugins": [
     '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',
-    '@semantic-release/github']
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md"
+      }
+    ],
+    [
+      "@google/semantic-release-replace-plugin",
+      {
+        "replacements": [
+          {
+            "files": ["manifests/metacontroller.yaml"],
+            "from": "metacontroller:v.*",
+            "to": "metacontroller:${nextRelease.version}",
+            "results": [
+              {
+                "file": "manifests/metacontroller.yaml",
+                "hasChanged": true,
+                "numMatches": 1,
+                "numReplacements": 1
+              }
+            ],
+            "countMatches": true
+          }
+        ]
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["CHANGELOG.md", "manifests/metacontroller.yaml"]
+      }
+    ],
+    [
+      '@semantic-release/github', 
+      {
+        "assets": ["manifests/*"]
+      }
+    ],
+  ]
 }


### PR DESCRIPTION
- manifests are now release asstest, available on release page
- on release, CHANGELOG.MD and manifests/metacontroller.yaml are updated