### PR TITLE
chore: Add renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,19 @@
+{
+  "extends": [
+    "config:base"
+  ],
+  "semanticCommits": "true",
+  "semanticCommitType": "fix",
+  "packageRules": [
+    {
+      "packagePatterns": "^k8s.io",
+      "semanticCommitType": "fix",
+      "separateMinorPatch": "true",
+      "groupName": ["k8s.io packages"]
+    },
+    {
+      "managers": ["dockerfile", "gomod"],
+      "semanticCommitType": "fix"
+    }
+  ]
+}


### PR DESCRIPTION
Adding basic renovate configuration for updating dependencies.

I separated k8s.io to be updated in single PR, also I separated to create different PR's for major versions.

All go/docker dependencies PR's will have commit with type `fix` to trigger release build.