### PR TITLE
fix(manifests): Fix image tag to match what exists

### DIFF
--- a/manifests/metacontroller.yaml
+++ b/manifests/metacontroller.yaml
@@ -64,7 +64,7 @@ spec:
       serviceAccountName: metacontroller
       containers:
       - name: metacontroller
-        image: metacontrollerio/metacontroller:0.4.5
+        image: metacontrollerio/metacontroller:v0.4.5
         command: ["/usr/bin/metacontroller"]
         args:
         - --logtostderr


### PR DESCRIPTION
metacontrollerio/metacontroller:0.4.5 does not exist on hub.docker.com.  All the tags currently there have a `v` prefix.