### PR TITLE
chore(examples): [#83] - Fix service-per-port sync hook

### DIFF
--- a/examples/service-per-pod/hooks/sync-service-per-pod.jsonnet
+++ b/examples/service-per-pod/hooks/sync-service-per-pod.jsonnet
@@ -19,6 +19,7 @@ function(request) {
         ports: [
           {
             local parts = std.split(portnums, ":"),
+            name: "port-" + std.parseInt(parts[0]),
             port: std.parseInt(parts[0]),
             targetPort: std.parseInt(parts[1]),
           }

--- a/examples/service-per-pod/my-statefulset.yaml
+++ b/examples/service-per-pod/my-statefulset.yaml
@@ -18,7 +18,7 @@ metadata:
   name: nginx
   annotations:
     service-per-pod-label: pod-name
-    service-per-pod-ports: "80:80"
+    service-per-pod-ports: "80:80,8080:8080"
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
In Later versions of kubernetes services with multiple ports need to have names for their ports.

This MR fixes the service-per-pod example