### PR TITLE
feat(perf): Add a flag to configure the number of workers to run

### DIFF
--- a/docs/src/guide/install.md
+++ b/docs/src/guide/install.md
@@ -55,3 +55,4 @@ in `manifests/metacontroller.yaml`):
 | `--client-config-path` | Path to kubeconfig file (same format as used by kubectl); if not specified, use in-cluster config (e.g. `--client-config-path=/path/to/kubeconfig`). |
 | `--client-go-qps` | Number of queries per second client-go is allowed to make (default 5, e.g. `--client-go-qps=100`) |
 | `--client-go-burst` |Allowed burst queries for client-go (default 10, e.g. `--client-go-burst=200`) |
+| `--workers` | Number of sync workers to run (default 5, e.g. `--workers=100`) |

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ var (
 	clientConfigPath  = flag.String("client-config-path", "", "Path to kubeconfig file (same format as used by kubectl); if not specified, use in-cluster config")
 	clientGoQPS       = flag.Float64("client-go-qps", 5, "Number of queries per second client-go is allowed to make (default 5)")
 	clientGoBurst     = flag.Int("client-go-burst", 10, "Allowed burst queries for client-go (default 10)")
+	workers           = flag.Int("workers", 5, "Number of sync workers to run (default 5)")
 )
 
 func main() {
@@ -71,7 +72,7 @@ func main() {
 	config.QPS = float32(*clientGoQPS)
 	config.Burst = *clientGoBurst
 
-	stopServer, err := server.Start(config, *discoveryInterval, *informerRelist)
+	stopServer, err := server.Start(config, *discoveryInterval, *informerRelist, *workers)
 	if err != nil {
 		glog.Fatal(err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -41,7 +41,7 @@ type controller interface {
 	Stop()
 }
 
-func Start(config *rest.Config, discoveryInterval, informerRelist time.Duration) (stop func(), err error) {
+func Start(config *rest.Config, discoveryInterval, informerRelist time.Duration, numWorkers int) (stop func(), err error) {
 	// Periodically refresh discovery to pick up newly-installed resources.
 	dc := discovery.NewDiscoveryClientForConfigOrDie(config)
 	resources := dynamicdiscovery.NewResourceMap(dc)
@@ -66,8 +66,8 @@ func Start(config *rest.Config, discoveryInterval, informerRelist time.Duration)
 	// Start metacontrollers (controllers that spawn controllers).
 	// Each one requests the informers it needs from the factory.
 	controllers := []controller{
-		composite.NewMetacontroller(resources, dynClient, dynInformers, mcInformerFactory, mcClient),
-		decorator.NewMetacontroller(resources, dynClient, dynInformers, mcInformerFactory),
+		composite.NewMetacontroller(resources, dynClient, dynInformers, mcInformerFactory, mcClient, numWorkers),
+		decorator.NewMetacontroller(resources, dynClient, dynInformers, mcInformerFactory, numWorkers),
 	}
 
 	// Start all requested informers.

--- a/test/integration/framework/main.go
+++ b/test/integration/framework/main.go
@@ -108,7 +108,7 @@ func testMain(tests func() int) error {
 	// metacontroller StatefulSet will not actually run anything.
 	// Instead, we start the Metacontroller server locally inside the test binary,
 	// since that's part of the code under test.
-	stopServer, err := server.Start(ApiserverConfig(), 500*time.Millisecond, 30*time.Minute)
+	stopServer, err := server.Start(ApiserverConfig(), 500*time.Millisecond, 30*time.Minute, 5)
 	if err != nil {
 		return fmt.Errorf("cannot start metacontroller server: %v", err)
 	}


### PR DESCRIPTION
This enables users to control how many webhook requests get processed in parallel.