### PR TITLE
fix(security): Update vunerable openssl packages  CVE-2020-1971

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,5 @@ RUN make vendor && go install
 
 FROM alpine:3.12.2
 COPY --from=build /go/bin/metacontroller.io /usr/bin/metacontroller
-RUN apk update && apk add --no-cache ca-certificates
+RUN apk update && apk add --no-cache ca-certificates openssl=1.1.1i-r0 libcrypto1.1=1.1.1i-r0 libssl1.1=1.1.1i-r0
 CMD ["/usr/bin/metacontroller"]

--- a/go.sum
+++ b/go.sum
@@ -780,6 +780,7 @@ k8s.io/klog/v2 v2.4.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/kube-openapi v0.0.0-20190816220812-743ec37842bf/go.mod h1:1TqjTSzOxsLGIKfj0lK8EeCP7K1iUG65v09OM0/WG5E=
 k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a h1:UcxjrRMyNx/i/y8G7kPvLyy7rfbeuf1PYyBf973pgyU=
 k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a/go.mod h1:1TqjTSzOxsLGIKfj0lK8EeCP7K1iUG65v09OM0/WG5E=
+k8s.io/kube-openapi v0.0.0-20200410145947-bcb3869e6f29 h1:NeQXVJ2XFSkRoPzRo8AId01ZER+j8oV4SZADT4iBOXQ=
 k8s.io/kube-openapi v0.0.0-20200410145947-bcb3869e6f29/go.mod h1:F+5wygcW0wmRTnM3cOgIqGivxkwSWIWT5YdsDbeAOaU=
 k8s.io/utils v0.0.0-20190801114015-581e00157fb1/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20191114184206-e782cd3c129f h1:GiPwtSzdP43eI1hpPCbROQCCIgCuiMMNF8YUVLF3vJo=

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
   ],
   "semanticCommits": "true",
   "semanticCommitType": "fix",
+  "pinDigests": "true",
   "packageRules": [
     {
       "packagePatterns": "^k8s.io",


### PR DESCRIPTION
Signed-off-by: grzesuav <grzesuav@gmail.com>

Temporary pin fixed dependency in docker file. Need to discuss better approach in future.