### PR TITLE
fix(docker): Disable `latest` tag for distroless variants

### DIFF
--- a/.github/workflows/release-pipeline.yaml
+++ b/.github/workflows/release-pipeline.yaml
@@ -42,6 +42,7 @@ jobs:
       uses: crazy-max/ghaction-docker-meta@v1
       with:
         images: metacontrollerio/metacontroller # list of Docker images to use as base name for tags
+        tag-latest: false
     - name: '[distroless] Build and push'
       id: docker_build_distroless
       uses: docker/build-push-action@v2
@@ -57,6 +58,7 @@ jobs:
       uses: crazy-max/ghaction-docker-meta@v1
       with:
         images: metacontrollerio/metacontroller # list of Docker images to use as base name for tags
+        tag-latest: false
     - name: '[distroless-debug] Build and push'
       id: docker_build_distroless_debug
       uses: docker/build-push-action@v2


### PR DESCRIPTION
Tested on https://github.com/grzesuav/metacontroller/runs/1736882334?check_suite_focus=true