### PR TITLE
fix(release): #197 - Change release message to trigger CI pipeline

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -33,7 +33,8 @@ module.exports = {
     [
       "@semantic-release/git",
       {
-        "assets": ["CHANGELOG.md", "manifests/production/metacontroller.yaml"]
+        "assets": ["CHANGELOG.md", "manifests/production/metacontroller.yaml"],
+        "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
       }
     ],
     [


### PR DESCRIPTION
Recently it break because of
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/

Signed-off-by: grzesuav <grzesuav@gmail.com>

