### PR TITLE
refactor: Switch code usage to external libraries (unstructured)

### DIFF
--- a/third_party/kubernetes/unstructured.go
+++ b/third_party/kubernetes/unstructured.go
@@ -17,26 +17,20 @@ import (
 	"fmt"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	"k8s.io/apimachinery/pkg/util/json"
 )
 
 // These are based on functions from k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.
 // They are copied here to make them exported.
 
-func GetNestedField(obj map[string]interface{}, fields ...string) interface{} {
-	var val interface{} = obj
-	for _, field := range fields {
-		if _, ok := val.(map[string]interface{}); !ok {
-			return nil
-		}
-		val = val.(map[string]interface{})[field]
-	}
-	return val
-}
-
 func GetNestedFieldInto(out interface{}, obj map[string]interface{}, fields ...string) error {
-	objMap := GetNestedField(obj, fields...)
-	if objMap == nil {
+	objMap, found, err := unstructured.NestedFieldNoCopy(obj, fields...)
+	if err != nil {
+		return fmt.Errorf("can't get nested field %v: %v", strings.Join(fields, "."), err)
+	}
+	if !found {
 		// If field has no value, leave `out` as is.
 		return nil
 	}
@@ -49,112 +43,4 @@ func GetNestedFieldInto(out interface{}, obj map[string]interface{}, fields ...s
 		return fmt.Errorf("can't decode nested field %v into type %T: %v", strings.Join(fields, "."), out, err)
 	}
 	return nil
-}
-
-func GetNestedString(obj map[string]interface{}, fields ...string) string {
-	if str, ok := GetNestedField(obj, fields...).(string); ok {
-		return str
-	}
-	return ""
-}
-
-func GetNestedArray(obj map[string]interface{}, fields ...string) []interface{} {
-	if arr, ok := GetNestedField(obj, fields...).([]interface{}); ok {
-		return arr
-	}
-	return nil
-}
-
-func GetNestedObject(obj map[string]interface{}, fields ...string) map[string]interface{} {
-	if nested_obj, ok := GetNestedField(obj, fields...).(map[string]interface{}); ok {
-		return nested_obj
-	}
-	return nil
-}
-
-func GetNestedInt64(obj map[string]interface{}, fields ...string) int64 {
-	if str, ok := GetNestedField(obj, fields...).(int64); ok {
-		return str
-	}
-	return 0
-}
-
-func GetNestedInt64Pointer(obj map[string]interface{}, fields ...string) *int64 {
-	nested := GetNestedField(obj, fields...)
-	switch n := nested.(type) {
-	case int64:
-		return &n
-	case *int64:
-		return n
-	default:
-		return nil
-	}
-}
-
-func GetNestedSlice(obj map[string]interface{}, fields ...string) []string {
-	if m, ok := GetNestedField(obj, fields...).([]interface{}); ok {
-		strSlice := make([]string, 0, len(m))
-		for _, v := range m {
-			if str, ok := v.(string); ok {
-				strSlice = append(strSlice, str)
-			}
-		}
-		return strSlice
-	}
-	return nil
-}
-
-func GetNestedMap(obj map[string]interface{}, fields ...string) map[string]string {
-	if m, ok := GetNestedField(obj, fields...).(map[string]interface{}); ok {
-		strMap := make(map[string]string, len(m))
-		for k, v := range m {
-			if str, ok := v.(string); ok {
-				strMap[k] = str
-			}
-		}
-		return strMap
-	}
-	return nil
-}
-
-func SetNestedField(obj map[string]interface{}, value interface{}, fields ...string) {
-	m := obj
-	if len(fields) > 1 {
-		for _, field := range fields[0 : len(fields)-1] {
-			if _, ok := m[field].(map[string]interface{}); !ok {
-				m[field] = make(map[string]interface{})
-			}
-			m = m[field].(map[string]interface{})
-		}
-	}
-	m[fields[len(fields)-1]] = value
-}
-
-func DeleteNestedField(obj map[string]interface{}, fields ...string) {
-	m := obj
-	if len(fields) > 1 {
-		for _, field := range fields[0 : len(fields)-1] {
-			if _, ok := m[field].(map[string]interface{}); !ok {
-				m[field] = make(map[string]interface{})
-			}
-			m = m[field].(map[string]interface{})
-		}
-	}
-	delete(m, fields[len(fields)-1])
-}
-
-func SetNestedSlice(obj map[string]interface{}, value []string, fields ...string) {
-	m := make([]interface{}, 0, len(value))
-	for _, v := range value {
-		m = append(m, v)
-	}
-	SetNestedField(obj, m, fields...)
-}
-
-func SetNestedMap(obj map[string]interface{}, value map[string]string, fields ...string) {
-	m := make(map[string]interface{}, len(value))
-	for k, v := range value {
-		m[k] = v
-	}
-	SetNestedField(obj, m, fields...)
 }


### PR DESCRIPTION
In this PR I removed `third_party/kubernetes` code and replace with calls to `unstructured`