### PR TITLE
docs: Fix invalid URLs in documentation

### DIFF
--- a/docs/src/contrib/build.md
+++ b/docs/src/contrib/build.md
@@ -9,7 +9,7 @@ First, check out the code:
 # place the repo according to the Go import path:
 #   $GOPATH/src/metacontroller.io
 cd $GOPATH/src
-git clone {{ site.repo_url }}.git metacontroller.io
+git clone git@github.com:metacontroller/metacontroller.git metacontroller.io
 cd metacontroller.io
 ```
 

--- a/docs/src/guide/install.md
+++ b/docs/src/guide/install.md
@@ -30,7 +30,7 @@ Replace `<user>` and `<domain>` above based on the account you use to authentica
 
 ```sh
 # Apply all set of production resources defined in kustomization.yaml in `production` directory .
-kubectl apply -k {{ site.repo_raw }}/manifests/production
+kubectl apply -k https://github.com/metacontroller/metacontroller/manifests/production
 
 ```
 


### PR DESCRIPTION
The documentation found at https://metacontroller.app/ contains raw variables which are not properly interpolated with actual values. Examples can be found in the [installation](https://metacontroller.github.io/metacontroller/guide/install.html#install-metacontroller) and [build](https://metacontroller.github.io/metacontroller/contrib/build.html#building) sections.

Looking at the capabilities of mdbook, there does not seem to be a well supported plugin for working with variables. I therefore decided to simply hardcode the actual values directly in the documentation source. 