### PR TITLE
test: Fix flakiness in integration tests

### DIFF
--- a/test/integration/framework/main.go
+++ b/test/integration/framework/main.go
@@ -85,7 +85,7 @@ func testMain(tests func() int) error {
 	start := time.Now()
 	for {
 		time.Sleep(time.Second)
-		kubectlErr := execKubectl("version")
+		kubectlErr := execKubectl("get", "namespaces")
 		if kubectlErr == nil {
 			break
 		}


### PR DESCRIPTION
The integration tests job in the CI fails occasionally and needs to be manually restarted.
After enabling more verbose logging, the error message that bubbles up seems to be [the server could not find the requested resource](https://github.com/fpetkovski/metacontroller/runs/2359962622?check_suite_focus=true#step:3:766). This error occurs when we try to create the metacontroller namespace before we run the integration test.

I assume what is happening is the apiserver is not fully initialized at this point and some kubernetes resources are not yet installed. To resolve the problem I changed the polling logic to use `kubectl get namespace` instead of `kubectl version`. This makes sure the namespace resource is available in the API before we move onward with the test.

Resolves https://github.com/metacontroller/metacontroller/issues/66