### PR TITLE
docs(pages): Switch docker image used to generation

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -8,15 +8,13 @@ on:
 jobs:
   gh-pages:
     runs-on: ubuntu-20.04
+    container:
+      image: "michaelfbryan/mdbook-docker-image:latest"
     if: github.repository_owner == 'metacontroller'
     steps:
     - uses: actions/checkout@v2
-    - name: Setup mdBook
-      uses: peaceiris/actions-mdbook@v1
-      with:
-        mdbook-version: '0.4.4'     
-        # mdbook-version: 'latest'
-    - run: |
+    - name: Build mdbook
+      run: |
         cd docs
         mdbook build
     - name: Deploy


### PR DESCRIPTION
To use https://github.com/Michael-F-Bryan/mdbook-docker-image as it has
all plugins for image generations

Signed-off-by: grzesuav <grzesuav@gmail.com>
