### PR TITLE
perf(k8sClient): use a cache-based version of k8s client

### DIFF
--- a/pkg/controller/common/common.go
+++ b/pkg/controller/common/common.go
@@ -92,14 +92,7 @@ func NewControllerContext(configuration options.Configuration, mcClient *mcclien
 	}
 	recorder := broadcaster.NewRecorder(scheme, corev1.EventSource{Component: "metacontroller"})
 
-	// Create a new Kubernetes client for interacting with the Kubernetes API
-	k8sClient, err := client.New(configuration.RestConfig, client.Options{})
-	if err != nil {
-		return nil, err
-	}
-
 	return &ControllerContext{
-		K8sClient:         k8sClient,
 		Resources:         resources,
 		DynClient:         dynClient,
 		DynInformers:      dynInformers,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -66,6 +66,11 @@ func New(configuration options.Configuration) (controllerruntime.Manager, func()
 		return nil, nil, err
 	}
 
+	// Set the Kubernetes client to the one created by the manager.
+	// In this way we can take advantage of the underlying caching
+	// mechanism for reads instead of hitting the API directly.
+	controllerContext.K8sClient = mgr.GetClient()
+
 	compositeReconciler := composite.NewMetacontroller(*controllerContext, mcClient, configuration.Workers)
 	compositeCtrl, err := controller.New("composite-metacontroller", mgr, controller.Options{
 		Reconciler: compositeReconciler,


### PR DESCRIPTION
The current metacontrollers use a plain controller-runtime client when talking to the API server.
As a result, each read and list action goes directly to the server instead of using a cache.

This commmit initializes the client to be the same as the one from the controller manager.
In this way, reading actions will always be backed by a cache, while write actions
will be executed directly against the API server.

Signed-off-by: fpetkovski <filip.petkovsky@gmail.com>