### PR TITLE
chore(examples): #68 - Add subresources status to example CRD

### DIFF
--- a/docs/src/guide/create.md
+++ b/docs/src/guide/create.md
@@ -50,6 +50,8 @@ spec:
     plural: helloworlds
     singular: helloworld
   scope: Namespaced
+  subresources:
+    status: {}
 ```
 
 Then apply it to your cluster:


### PR DESCRIPTION
The CRD example from the guide is missing the subresources status entry and without it the controller won't work, error is below.
```
metacontroller.go:126] "Ignoring CompositeController" name="hello-controller" reason="subresource 'Status' not enabled" groupVersionKind="example.com/v1, Kind=HelloWorld"
```
Ref https://stackoverflow.com/questions/56427423/metacontroller-how-to-stop-calls-to-sync-hooks-and-resource-generation/