### PR TITLE
perf(webhooks): #255 - Create httpClient per controller instead ad-hoc creation

### DIFF
--- a/pkg/controller/common/customize/hook.go
+++ b/pkg/controller/common/customize/hook.go
@@ -17,41 +17,25 @@ limitations under the License.
 package customize
 
 import (
-	"fmt"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"metacontroller/pkg/apis/metacontroller/v1alpha1"
-	"metacontroller/pkg/hooks"
 )
 
-var callCustomizeHook = hooks.Call
-
+// CustomizableController is an interface representing Controller exposing customize hook
 type CustomizableController interface {
+
+	// GetCustomizeHook return v1alpha1.Hook or nil if not defined
 	GetCustomizeHook() *v1alpha1.Hook
 }
 
+// CustomizeHookRequest is a request send to customize hook
 type CustomizeHookRequest struct {
 	Controller CustomizableController     `json:"controller"`
 	Parent     *unstructured.Unstructured `json:"parent"`
 }
 
+// CustomizeHookResponse is a response from customize hook
 type CustomizeHookResponse struct {
 	RelatedResourceRules []*v1alpha1.RelatedResourceRule `json:"relatedResources,omitempty"`
-}
-
-func CallCustomizeHook(cc CustomizableController, request *CustomizeHookRequest) (*CustomizeHookResponse, error) {
-	var response CustomizeHookResponse
-
-	hook := cc.GetCustomizeHook()
-	// As the related hook is optional, return nothing
-	if hook == nil {
-		return &response, nil
-	}
-
-	if err := callCustomizeHook(hook, hooks.CustomizeHook, request, &response); err != nil {
-		return nil, fmt.Errorf("related hook failed: %w", err)
-	}
-
-	return &response, nil
 }

--- a/pkg/controller/common/finalizer/finalizer.go
+++ b/pkg/controller/common/finalizer/finalizer.go
@@ -30,6 +30,14 @@ type Manager struct {
 	Enabled bool
 }
 
+// NewManager return new Manager for dealing with finalizers.
+func NewManager(name string, enabled bool) *Manager {
+	return &Manager{
+		Name:    name,
+		Enabled: enabled,
+	}
+}
+
 // SyncObject adds or removes the finalizer on the given object as necessary.
 func (m *Manager) SyncObject(client *dynamicclientset.ResourceClient, obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
 	// If the cached object passed in is already in the right state,

--- a/pkg/controller/composite/controller_revision.go
+++ b/pkg/controller/composite/controller_revision.go
@@ -88,7 +88,7 @@ func (pc *parentController) syncRevisions(parent *unstructured.Unstructured, obs
 			Children:   observedChildren,
 			Related:    relatedObjects,
 		}
-		syncResult, err := callSyncHook(pc.cc, syncRequest)
+		syncResult, err := pc.callHook(syncRequest)
 		if err != nil {
 			return nil, fmt.Errorf("sync hook failed for %v %v/%v: %w", pc.parentResource.Kind, parent.GetNamespace(), parent.GetName(), err)
 		}
@@ -163,7 +163,7 @@ func (pc *parentController) syncRevisions(parent *unstructured.Unstructured, obs
 				Parent:     pr.parent,
 				Children:   observedChildren,
 			}
-			syncResult, err := callSyncHook(pc.cc, syncRequest)
+			syncResult, err := pc.callHook(syncRequest)
 			if err != nil {
 				pr.syncError = err
 				return

--- a/pkg/hooks/hooks_test.go
+++ b/pkg/hooks/hooks_test.go
@@ -1,0 +1,32 @@
+package hooks
+
+import (
+	"metacontroller/pkg/apis/metacontroller/v1alpha1"
+	"testing"
+)
+
+func TestNewHookExecutor_whenNilHook_returnDisabledHookExecutor(t *testing.T) {
+	executor, err := NewHookExecutor(nil, "")
+
+	if err != nil {
+		t.Errorf("err should be nil, got: %v", err)
+	}
+
+	if executor.IsEnabled() {
+		t.Errorf("HookExecutor should be disabled")
+	}
+}
+
+func TestNewHookExecutor_whenHookWithNilWebhook_returnDisabledHookExecutor(t *testing.T) {
+	executor, err := NewHookExecutor(&v1alpha1.Hook{
+		Webhook: nil},
+		"")
+
+	if err != nil {
+		t.Errorf("err should be nil, got: %v", err)
+	}
+
+	if executor.IsEnabled() {
+		t.Errorf("HookExecutor should be disabled")
+	}
+}

--- a/pkg/hooks/webhook_test.go
+++ b/pkg/hooks/webhook_test.go
@@ -11,6 +11,18 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func TestNewHookExecutor_whenNilWebHook_returnNilWebhookExecutor(t *testing.T) {
+	executor, err := NewWebhookExecutor(nil, "")
+
+	if err != nil {
+		t.Errorf("err should be nil, got: %v", err)
+	}
+
+	if executor != nil {
+		t.Errorf("WebhookExecutor should be nil")
+	}
+}
+
 func TestWebhookTimeout_defaultTimeoutIfNotSpecified(t *testing.T) {
 	tables := []struct {
 		webhook  v1alpha1.Webhook

--- a/pkg/internal/testutils/hooks.go
+++ b/pkg/internal/testutils/hooks.go
@@ -1,0 +1,43 @@
+package testutils
+
+import (
+	"fmt"
+	"metacontroller/pkg/hooks"
+	"reflect"
+)
+
+// NewHookExecutorStub creates new HookExecutorStub which returns given response
+func NewHookExecutorStub(response interface{}) hooks.HookExecutor {
+	return &hookExecutorStub{
+		enabled:  true,
+		response: response,
+	}
+}
+
+// HookExecutorStub is HookExecutor stub to return any given response
+type hookExecutorStub struct {
+	enabled  bool
+	response interface{}
+}
+
+func (h *hookExecutorStub) IsEnabled() bool {
+	return true
+}
+
+func (h *hookExecutorStub) Execute(request interface{}, response interface{}) error {
+	val := reflect.ValueOf(response)
+	if val.Kind() != reflect.Ptr {
+		return fmt.Errorf(`panic("not a pointer")`)
+	}
+
+	val = val.Elem()
+
+	newVal := reflect.Indirect(reflect.ValueOf(h.response))
+
+	if !val.Type().AssignableTo(newVal.Type()) {
+		return fmt.Errorf(`panic("mismatched types")`)
+	}
+
+	val.Set(newVal)
+	return nil
+}


### PR DESCRIPTION
Up to now, for each invocation new httpClient was created. It was both
unefficient and forbids from further changes (like adding authentication
etc). This PR introduces Hooks Executor which are partof the controller.