### PR TITLE
fix(metrics): Add http client metrics

### DIFF
--- a/examples/prometheus-monitoring/README.MD
+++ b/examples/prometheus-monitoring/README.MD
@@ -1,0 +1,31 @@
+# Monitoring via prometheus-operator stack
+
+One of the ways to monitor metacontroller.
+
+### Prerequisites
+
+* Install [Metacontroller](https://github.com/metacontroller/metacontroller)
+
+## Installation
+* install prometheus-operator - `kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.49.0/bundle.yaml`
+  * wait till `Pod` `prometheus-operator-xxx` is ready (in namespace `default`)
+* apply prometheus configuration - `kubectl apply -f examples/prometheus-monitoring/prometheus.yaml`
+  * wait till `Pod` `prometheus-prometheus-0` is ready (in namespace `default`)
+
+This example shows how to use [Prometheus operator](https://prometheus-operator.dev/) to spin up
+a [Prometheus](https://prometheus.io/) instance for monitoring metacontroller.
+
+## Viewing metrics
+* port forward prometheus UI port to localhost - `kubectl -n default port-forward prometheus-prometheus-0 9090:9090`
+* run test suite (`cd examples && ./test.sh`) 
+* go to `http://localhost:9090/`, you should see prometheus UI
+* to see all available metrics, use expression `{namespace="metacontroller"}` in query browser
+
+Currently exposed metrics are:
+* [Controller runtime metrics](https://book-v1.book.kubebuilder.io/beyond_basics/controller_metrics.html)
+* client-go metrics (i.e., workquene or API server connections latency)
+* go system metrics (usually with `go_` prefix in name)
+* metacontroller own metrics (with `metacontroller_` prefix, i.e. `metacontroller_sync_requests_total`)
+
+
+New metrics will be added along the way, please let us know what insight information you would like to see,

--- a/examples/prometheus-monitoring/prometheus.yaml
+++ b/examples/prometheus-monitoring/prometheus.yaml
@@ -1,0 +1,96 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - nodes/metrics
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    verbs: ["get"]
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs: ["get", "list", "watch"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: default
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: prometheus
+  namespace: default
+  labels:
+    app: prometheus
+spec:
+  version: v2.28.1
+  replicas: 1
+  resources:
+    requests:
+      memory: 400Mi
+  securityContext:
+    fsGroup: 2000
+    runAsNonRoot: true
+    runAsUser: 1000
+  serviceAccountName: prometheus
+  serviceMonitorSelector: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: metacontroller
+  namespace: metacontroller
+  labels:
+    app.kubernetes.io/name: metacontroller
+spec:
+  ports:
+    - port: 9999
+      name: http
+      targetPort: 9999
+  selector:
+    app.kubernetes.io/name: metacontroller
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: metacontroller
+  namespace: default
+  labels:
+    app.kubernetes.io/name: metacontroller
+spec:
+  endpoints:
+    - interval: 5s
+      port: http
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: metacontroller
+  namespaceSelector:
+    matchNames:
+      - metacontroller

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-logr/logr v0.4.0
 	github.com/google/go-cmp v0.5.6
 	github.com/nsf/jsondiff v0.0.0-20210303162244-6ea32392771e // test
+	github.com/prometheus/client_golang v1.11.0
 	go.uber.org/zap v1.18.1
 	k8s.io/api v0.21.3
 	k8s.io/apimachinery v0.21.3
@@ -16,6 +17,7 @@ require (
 	k8s.io/klog/v2 v2.10.0
 	k8s.io/utils v0.0.0-20210722164352-7f3ee0f31471
 	sigs.k8s.io/controller-runtime v0.9.5
+	zgo.at/zcache v1.0.0
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -741,3 +741,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.1.2/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZa
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
+zgo.at/zcache v1.0.0 h1:jeQ/2ZHw76P4acf7LqFKJeil8NVyAY+bDrvKwq4XTjI=
+zgo.at/zcache v1.0.0/go.mod h1:xWQo2ha/bamTmx8CbfrZl9Nf8AoT5uNh2hWfbQi8TiE=

--- a/manifests/debug/args.yaml
+++ b/manifests/debug/args.yaml
@@ -11,6 +11,6 @@ spec:
       - name: metacontroller
         command: ["/dlv", "--listen=:40000", "--headless=true", "--api-version=2", "exec", "/usr/bin/metacontroller", "--"]
         args:
-        - --logtostderr
-        - -v=5
+        - --zap-devel
+        - --zap-log-level=5
         - --discovery-interval=5s

--- a/pkg/controller/common/common.go
+++ b/pkg/controller/common/common.go
@@ -59,6 +59,25 @@ func init() {
 	}
 }
 
+type HookType string
+type ControllerType string
+
+const (
+	FinalizeHook        HookType       = "finalize"
+	CustomizeHook       HookType       = "customize"
+	SyncHook            HookType       = "sync"
+	CompositeController ControllerType = "CompositeController"
+	DecoratorController ControllerType = "DecoratorController"
+)
+
+func (h HookType) String() string {
+	return string(h)
+}
+
+func (c ControllerType) String() string {
+	return string(c)
+}
+
 // ControllerContext holds various object related to interacting with kubernetes cluster
 type ControllerContext struct {
 	// K8sClient is a client used to interact with the Kubernetes API

--- a/pkg/controller/common/customize/cache_test.go
+++ b/pkg/controller/common/customize/cache_test.go
@@ -28,8 +28,8 @@ func TestAdd_ElementFirstTime(t *testing.T) {
 
 	expected := customizeResponseCacheEntry{parentGeneration: 12, cachedResponse: &mockResponse}
 
-	if responseCache.cache["some"] != expected {
-		t.Errorf("Incorrect responseCache entry, got: %v, expected: %v", responseCache.cache["someName"], expected)
+	if cachedElement := responseCache.Get("some", 12); cachedElement != expected.cachedResponse {
+		t.Errorf("Incorrect responseCache entry, got: %v, expected: %v", cachedElement, expected)
 	}
 }
 
@@ -41,8 +41,11 @@ func TestAdd_ElementOverridePreviousOne(t *testing.T) {
 
 	responseCache.Add("some", 14, &mockResponse)
 
-	if responseCache.cache["some"] != expected {
-		t.Errorf("Incorrect cache entry, got: %v, expected: %v", responseCache.cache["someName"], expected)
+	if cachedElement := responseCache.Get("some", 14); cachedElement != expected.cachedResponse {
+		t.Errorf("Incorrect cache entry, got: %v, expected: %v", cachedElement, expected)
+	}
+	if cachedElement := responseCache.Get("some", 12); cachedElement != nil {
+		t.Errorf("Incorrect cache entry, got: %v, expected nil", cachedElement)
 	}
 }
 

--- a/pkg/controller/common/customize/manager_test.go
+++ b/pkg/controller/common/customize/manager_test.go
@@ -62,6 +62,7 @@ var customizeManagerWithNilController, _ = NewCustomizeManager(
 	make(common.InformerMap),
 	make(common.GroupKindMap),
 	nil,
+	common.CompositeController,
 )
 
 var customizeManagerWithFakeController, _ = NewCustomizeManager(
@@ -73,6 +74,7 @@ var customizeManagerWithFakeController, _ = NewCustomizeManager(
 	make(common.InformerMap),
 	make(common.GroupKindMap),
 	nil,
+	common.DecoratorController,
 )
 
 func TestGetRelatedObjects_whenHookDisabled_returnEmptyMap(t *testing.T) {

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -18,12 +18,7 @@ package hooks
 
 import (
 	"metacontroller/pkg/apis/metacontroller/v1alpha1"
-)
-
-const (
-	FinalizeHook  string = "finalize"
-	CustomizeHook string = "customize"
-	SyncHook      string = "sync"
+	"metacontroller/pkg/controller/common"
 )
 
 // HookExecutor an execute Hook requests
@@ -33,9 +28,13 @@ type HookExecutor interface {
 }
 
 // NewHookExecutor return new HookExecutor which implements given v1alpha1.Hook
-func NewHookExecutor(hook *v1alpha1.Hook, hookType string) (HookExecutor, error) {
+func NewHookExecutor(
+	hook *v1alpha1.Hook,
+	controllerName string,
+	controllerType common.ControllerType,
+	hookType common.HookType) (HookExecutor, error) {
 	if hook != nil {
-		executor, err := NewWebhookExecutor(hook.Webhook, hookType)
+		executor, err := NewWebhookExecutor(hook.Webhook, controllerName, controllerType, hookType)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/hooks/hooks_test.go
+++ b/pkg/hooks/hooks_test.go
@@ -2,11 +2,12 @@ package hooks
 
 import (
 	"metacontroller/pkg/apis/metacontroller/v1alpha1"
+	"metacontroller/pkg/controller/common"
 	"testing"
 )
 
 func TestNewHookExecutor_whenNilHook_returnDisabledHookExecutor(t *testing.T) {
-	executor, err := NewHookExecutor(nil, "")
+	executor, err := NewHookExecutor(nil, "", common.CompositeController, "")
 
 	if err != nil {
 		t.Errorf("err should be nil, got: %v", err)
@@ -20,7 +21,7 @@ func TestNewHookExecutor_whenNilHook_returnDisabledHookExecutor(t *testing.T) {
 func TestNewHookExecutor_whenHookWithNilWebhook_returnDisabledHookExecutor(t *testing.T) {
 	executor, err := NewHookExecutor(&v1alpha1.Hook{
 		Webhook: nil},
-		"")
+		"", common.CompositeController, "")
 
 	if err != nil {
 		t.Errorf("err should be nil, got: %v", err)

--- a/pkg/hooks/webhook_test.go
+++ b/pkg/hooks/webhook_test.go
@@ -1,6 +1,7 @@
 package hooks
 
 import (
+	"metacontroller/pkg/controller/common"
 	"testing"
 	"time"
 
@@ -12,7 +13,7 @@ import (
 )
 
 func TestNewHookExecutor_whenNilWebHook_returnNilWebhookExecutor(t *testing.T) {
-	executor, err := NewWebhookExecutor(nil, "")
+	executor, err := NewWebhookExecutor(nil, "", common.CompositeController, "")
 
 	if err != nil {
 		t.Errorf("err should be nil, got: %v", err)

--- a/pkg/internal/testutils/hooks.go
+++ b/pkg/internal/testutils/hooks.go
@@ -41,3 +41,5 @@ func (h *hookExecutorStub) Execute(request interface{}, response interface{}) er
 	val.Set(newVal)
 	return nil
 }
+
+func (h hookExecutorStub) Close() {}

--- a/pkg/metrics/http.go
+++ b/pkg/metrics/http.go
@@ -1,0 +1,204 @@
+//  MIT License
+//
+//  © Copyright 2019 travel audience. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+// code based on https://github.com/travelaudience/go-promhttp/blob/master/client.go
+
+package metrics
+
+import (
+	"fmt"
+	"metacontroller/pkg/controller/common"
+	"net/http"
+	"time"
+
+	controllerruntimemetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"zgo.at/zcache"
+
+	"github.com/prometheus/client_golang/prometheus"
+	pph "github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+const metacontrollerPrefix = "metacontroller"
+
+var cache = zcache.New(20*time.Minute, 10*time.Minute)
+var registerer = controllerruntimemetrics.Registry
+
+// InstrumentClientWithConstLabels instruments given http.Client with metrics registered in given prometheus.Registerer
+func InstrumentClientWithConstLabels(
+	controllerName string,
+	controllerType common.ControllerType,
+	hookType common.HookType,
+	c *http.Client,
+	url string) (*http.Client, error) {
+	constLabels := map[string]string{
+		"url":             url,
+		"controller_name": controllerName,
+		"controller_type": controllerType.String(),
+	}
+	key := fmt.Sprintf("%s/%s/%s", controllerName, hookType, url)
+	instrumentation, err := getOrCreateMetrics(key, hookType, constLabels)
+	if err != nil {
+		return nil, err
+	}
+
+	transport := c.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	client := &http.Client{
+		CheckRedirect: c.CheckRedirect,
+		Jar:           c.Jar,
+		Timeout:       c.Timeout,
+		Transport: pph.InstrumentRoundTripperInFlight(instrumentation.Collector.inflight,
+			pph.InstrumentRoundTripperCounter(instrumentation.Collector.requests,
+				pph.InstrumentRoundTripperTrace(instrumentation.Trace,
+					pph.InstrumentRoundTripperDuration(instrumentation.Collector.duration, transport),
+				),
+			),
+		),
+	}
+	return client, nil
+}
+
+func getOrCreateMetrics(key string, hookType common.HookType, constLabels map[string]string) (*cachedInstrumentation, error) {
+	instrumentationCacheEntry, found := cache.Get(key)
+	var instrumentation *cachedInstrumentation
+	if !found {
+		collector, trace := createNewMetrics(hookType, constLabels)
+		newCacheEntry := &cachedInstrumentation{
+			Collector: collector,
+			Trace:     trace,
+		}
+		cache.Set(key, newCacheEntry, zcache.NoExpiration)
+		instrumentation = newCacheEntry
+		err := registerer.Register(instrumentation.Collector)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		instrumentation = instrumentationCacheEntry.(*cachedInstrumentation)
+	}
+	return instrumentation, nil
+}
+
+func createNewMetrics(hookType common.HookType, constLabels map[string]string) (*instrumentation, *pph.InstrumentTrace) {
+	outgoingInstrumentation := &instrumentation{
+		requests: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace:   metacontrollerPrefix,
+				Subsystem:   hookType.String(),
+				Name:        "requests_total",
+				Help:        "A counter for outgoing requests from the wrapped client.",
+				ConstLabels: constLabels,
+			},
+			[]string{"code", "method"},
+		),
+		duration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace:   metacontrollerPrefix,
+				Subsystem:   hookType.String(),
+				Name:        "request_duration_histogram_seconds",
+				Help:        "A histogram of outgoing request latencies.",
+				Buckets:     prometheus.DefBuckets,
+				ConstLabels: constLabels,
+			},
+			[]string{"method"},
+		),
+		dnsDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace:   metacontrollerPrefix,
+				Subsystem:   hookType.String(),
+				Name:        "dns_duration_histogram_seconds",
+				Help:        "Trace dns latency histogram.",
+				Buckets:     []float64{.005, .01, .025, .05},
+				ConstLabels: constLabels,
+			},
+			[]string{"event"},
+		),
+		tlsDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace:   metacontrollerPrefix,
+				Subsystem:   hookType.String(),
+				Name:        "tls_duration_histogram_seconds",
+				Help:        "Trace tls latency histogram.",
+				Buckets:     []float64{.05, .1, .25, .5},
+				ConstLabels: constLabels,
+			},
+			[]string{"event"},
+		),
+		inflight: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace:   metacontrollerPrefix,
+			Subsystem:   hookType.String(),
+			Name:        "in_flight_requests",
+			Help:        "A gauge of in-flight outgoing requests for the wrapped client.",
+			ConstLabels: constLabels,
+		}),
+	}
+
+	trace := &pph.InstrumentTrace{
+		DNSStart: func(t float64) {
+			outgoingInstrumentation.dnsDuration.WithLabelValues("dns_start").Observe(t)
+		},
+		DNSDone: func(t float64) {
+			outgoingInstrumentation.dnsDuration.WithLabelValues("dns_done").Observe(t)
+		},
+		TLSHandshakeStart: func(t float64) {
+			outgoingInstrumentation.tlsDuration.WithLabelValues("tls_handshake_start").Observe(t)
+		},
+		TLSHandshakeDone: func(t float64) {
+			outgoingInstrumentation.tlsDuration.WithLabelValues("tls_handshake_done").Observe(t)
+		},
+	}
+	return outgoingInstrumentation, trace
+}
+
+type cachedInstrumentation struct {
+	Collector *instrumentation
+	Trace     *pph.InstrumentTrace
+}
+
+type instrumentation struct {
+	duration    *prometheus.HistogramVec
+	requests    *prometheus.CounterVec
+	dnsDuration *prometheus.HistogramVec
+	tlsDuration *prometheus.HistogramVec
+	inflight    prometheus.Gauge
+}
+
+// Describe implements prometheus.Collector interface.
+func (i *instrumentation) Describe(in chan<- *prometheus.Desc) {
+	i.duration.Describe(in)
+	i.requests.Describe(in)
+	i.dnsDuration.Describe(in)
+	i.tlsDuration.Describe(in)
+	i.inflight.Describe(in)
+}
+
+// Collect implements prometheus.Collector interface.
+func (i *instrumentation) Collect(in chan<- prometheus.Metric) {
+	i.duration.Collect(in)
+	i.requests.Collect(in)
+	i.dnsDuration.Collect(in)
+	i.tlsDuration.Collect(in)
+	i.inflight.Collect(in)
+}

--- a/pkg/metrics/http_test.go
+++ b/pkg/metrics/http_test.go
@@ -1,0 +1,1 @@
+package metrics

--- a/test/integration/go.sum
+++ b/test/integration/go.sum
@@ -741,3 +741,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.1.2/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZa
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
+zgo.at/zcache v1.0.0 h1:jeQ/2ZHw76P4acf7LqFKJeil8NVyAY+bDrvKwq4XTjI=
+zgo.at/zcache v1.0.0/go.mod h1:xWQo2ha/bamTmx8CbfrZl9Nf8AoT5uNh2hWfbQi8TiE=


### PR DESCRIPTION
Signed-off-by: grzesuav <grzesuav@gmail.com>

# Details

1. Adding http client metrics, I needed to add caching mechanism to metrics, as user can de-register and re-register the same controller, and I cannot twice register the same metrics. 
2. Changed caching mechanism to store CustomizeHookResponses to expiring cache (previous implementation did't  clear old entries)
3. Minor fixes, like correct name of customize controller or passed actual loggers instead of `nil`