### PR TITLE
fix(hooks): check if should finalize before calling hook

### DIFF
--- a/pkg/controller/composite/hooks.go
+++ b/pkg/controller/composite/hooks.go
@@ -50,7 +50,7 @@ func (pc *parentController) callHook(request *SyncHookRequest) (*SyncHookRespons
 	// First check if we should instead call the finalize hook,
 	// which has the same API as the sync hook except that it's
 	// called while the object is pending deletion.
-	if request.Parent.GetDeletionTimestamp() != nil && pc.finalizeHook.IsEnabled() {
+	if request.Parent.GetDeletionTimestamp() != nil && pc.finalizeHook.IsEnabled() && pc.finalizer.ShouldFinalize(request.Parent) {
 		// Finalize
 		request.Finalizing = true
 		if err := pc.finalizeHook.Execute(request, &response); err != nil {

--- a/pkg/controller/decorator/hooks.go
+++ b/pkg/controller/decorator/hooks.go
@@ -62,7 +62,7 @@ func (c *decoratorController) callHook(request *SyncHookRequest) (*SyncHookRespo
 	// when the object no longer matches our decorator selector.
 	// This allows the decorator to clean up after itself if the object has been
 	// updated to disable the functionality added by the decorator.
-	if c.finalizeHook.IsEnabled() &&
+	if c.finalizeHook.IsEnabled() && c.finalizer.ShouldFinalize(request.Object) &&
 		(request.Object.GetDeletionTimestamp() != nil || !c.parentSelector.Matches(request.Object)) {
 		// Finalize
 		request.Finalizing = true


### PR DESCRIPTION
When a GC finalizer is on the parent (.e.g, foregroundDeletion), I noticed the finalizer hook was getting called immediately during delete instead of waiting for the GC finalizer to be removed. This should wait for the GC finalizer to be removed before calling the finalizer hook. 

I have made an assumption on the expected behavior here. If this is wrong, feel free to close the PR.