### PR TITLE
feat: Add K8s API communication check on startup

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,10 +53,16 @@ func main() {
 	flag.Parse()
 	logging.InitLogging(&opts)
 
-	logging.Logger.Info("Discovery cache flush interval", "discovery_interval", *discoveryInterval)
-	logging.Logger.Info("API server object cache flush interval", "cache_flush_interval", *informerRelist)
-	logging.Logger.Info("Metrics http server address", "port", *metricsAddr)
-	logging.Logger.Info("Metacontroller build information", "version", version)
+	logging.Logger.Info("Configuration information",
+		"discovery-interval", *discoveryInterval,
+		"cache-flush-interval", *informerRelist,
+		"metrics-address", *metricsAddr,
+		"client-go-qps", *clientGoQPS,
+		"client-go-burst", *clientGoBurst,
+		"workers", *workers,
+		"events-qps", *eventsQPS,
+		"events-burst", *eventsBurst,
+		"version", version)
 
 	config, err := controllerruntime.GetConfig()
 	if err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -17,7 +17,12 @@ limitations under the License.
 package server
 
 import (
+	"context"
 	"fmt"
+	"metacontroller/pkg/logging"
+	"time"
+
+	"k8s.io/client-go/discovery"
 
 	"metacontroller/pkg/controller/common"
 
@@ -45,6 +50,13 @@ func New(configuration options.Configuration) (controllerruntime.Manager, error)
 	mcClient, err := mcclientset.NewForConfig(configuration.RestConfig)
 	if err != nil {
 		return nil, fmt.Errorf("can't create client for api %s: %w", v1alpha1.SchemeGroupVersion, err)
+	}
+
+	// Check if metacontroller can successfully communicate with the K8s API server
+	// If metacontroller is in a service mesh, this serves as a check that the sidecar is healthy
+	err = k8sCommunicationCheck(mcClient.DiscoveryClient)
+	if err != nil {
+		return nil, fmt.Errorf("communication with K8s API server failed.: %w", err)
 	}
 
 	controllerContext, err := common.NewControllerContext(configuration, mcClient)
@@ -101,4 +113,19 @@ func New(configuration options.Configuration) (controllerruntime.Manager, error)
 	controllerContext.Start()
 
 	return mgr, nil
+}
+
+func k8sCommunicationCheck(client *discovery.DiscoveryClient) (err error) {
+	// retry 6 times with a delay of 5 seconds each retry
+	for range [6]int{} {
+		_, err := client.RESTClient().Get().AbsPath("/api").DoRaw(context.TODO())
+		if err == nil {
+			logging.Logger.Info("Communication with K8s API server successful")
+			break
+		}
+
+		logging.Logger.Info("Communication with K8s API server failed. Retrying...")
+		time.Sleep(5 * time.Second)
+	}
+	return err
 }


### PR DESCRIPTION
The purpose of this PR is to avoid container restarts on startup when metacontroller is in a service mesh (istio, kuma, etc). If the service mesh sidecar takes longer to come up than metacontroller, then metacontroller will have container restarts. The K8s API healthcheck lets us know that the sidecar is properly communicating and the API server is healthy.