### PR TITLE
fix(discovery): Do not fail if missing a subset of resources during API discover

### DIFF
--- a/pkg/dynamic/discovery/discovery.go
+++ b/pkg/dynamic/discovery/discovery.go
@@ -99,8 +99,11 @@ func (rm *ResourceMap) refresh() {
 	logging.Logger.V(7).Info("Refreshing API discovery info")
 	_, groups, err := rm.discoveryClient.ServerGroupsAndResources()
 	if err != nil {
-		logging.Logger.Error(err, "Failed to fetch discovery info")
-		return
+		if len(groups) == 0 {
+			logging.Logger.Error(err, "Failed to fetch discovery info")
+			return
+		}
+		logging.Logger.Error(err, "Failed to fetch all resources, continuing with partial discovery info")
 	}
 
 	// Denormalize resource lists into maps for convenient lookup

--- a/pkg/dynamic/discovery/discovery.go
+++ b/pkg/dynamic/discovery/discovery.go
@@ -103,7 +103,7 @@ func (rm *ResourceMap) refresh() {
 			logging.Logger.Error(err, "Failed to fetch discovery info")
 			return
 		}
-		logging.Logger.Error(err, "Failed to fetch all resources, continuing with partial discovery info")
+		logging.Logger.V(4).Info("Failed to fetch all resources, continuing with partial discovery info", "failures", err)
 	}
 
 	// Denormalize resource lists into maps for convenient lookup


### PR DESCRIPTION
The purpose of this PR is to avoid completely failing API discovery if only a subset of resources fail to be fetched.

In my particular case, another team managing keda-operator-metrics-apiserver occasionally goes into a bad state causing an error discovery resources. If metacontroller is starting up for the first time, then it will get an error fetching resources and be blocked until the keda operator is in a good state and responds with resources during API discovery.

```{"level":"error","ts":1638640761.0517867,"msg":"Failed to fetch discovery info","error":"unable to retrieve the complete list of server APIs: external.metrics.k8s.io/v1beta1: the server is currently unable to handle the request","stacktrace":"metacontroller/pkg/dynamic/discovery.(*ResourceMap).Start.func1\n\t/go/src/metacontroller/pkg/dynamic/discovery/discovery.go:179"}```