### PR TITLE
docs: Add disable serving metrics info if port 0

### DIFF
--- a/docs/src/guide/configuration.md
+++ b/docs/src/guide/configuration.md
@@ -18,7 +18,7 @@ in `manifests/metacontroller.yaml`):
 | `--zap-stacktrace-level` | Zap Level at and above which stacktraces are captured - one of `info` or `error` (e.g. `--zap-stacktrace-level='info'`). |
 | `--discovery-interval` | How often to refresh discovery cache to pick up newly-installed resources (e.g. `--discovery-interval=10s`). |
 | `--cache-flush-interval` | How often to flush local caches and relist objects from the API server (e.g. `--cache-flush-interval=30m`). |
-| `--metrics-address` | The address to bind metrics endpoint - /metrics (e.g. `--metrics-address=":9999"`). |
+| `--metrics-address` | The address to bind metrics endpoint - /metrics (e.g. `--metrics-address=":9999"`). It can be set to "0" to disable the metrics serving. |
 | `--kubeconfig` | Path to kubeconfig file (same format as used by kubectl); if not specified, use in-cluster config (e.g. `--kubeconfig=/path/to/kubeconfig`). |
 | `--client-go-qps` | Number of queries per second client-go is allowed to make (default 5, e.g. `--client-go-qps=100`) |
 | `--client-go-burst` | Allowed burst queries for client-go (default 10, e.g. `--client-go-burst=200`) |


### PR DESCRIPTION
I was troubleshooting a couple things and wanted to disable prometheus metrics and came across the ability to disable it by setting the port to 0. See: https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/manager/manager.go#L199

@grzesuav @AmitKumarDas  I am thinking it might be better to default the value to 0 and have the user enable it if necessary. Thoughts?