### PR TITLE
chore(helm): #302 - add custom arguments to the helm chart

### DIFF
--- a/deploy/helm/metacontroller/templates/statefulset.yaml
+++ b/deploy/helm/metacontroller/templates/statefulset.yaml
@@ -50,6 +50,9 @@ spec:
           {{- if .Values.cacheFlushInterval -}}
           - --cache-flush-interval={{.Values.cacheFlushInterval}}
           {{ end -}}
+          {{- range $value := .Values.commandArgs }}
+          - {{ $value | quote }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/deploy/helm/metacontroller/values.yaml
+++ b/deploy/helm/metacontroller/values.yaml
@@ -51,6 +51,11 @@ zap: {}
   # encoder: "json"
   # stacktraceLevel: "info"
 
+# Custom arguments which are used to start metacontroller
+commandArgs: []
+# - --client-go-qps=100
+# - --client-go-burst=200
+
 # How often to refresh discovery cache to pick up newly-installed resources
 discoveryInterval: 20s
 


### PR DESCRIPTION
I have a usecase to be able to modify the metacontroller arguments when deploying it with the helm chart.

I have added the ability to add custom command line arguments to the helm chart. This way if the arguments change in the future we can keep the helm chart the way it is.