### PR TITLE
fix: change invalid log message when InPlace update strategy is used

### DIFF
--- a/pkg/controller/common/manage_children.go
+++ b/pkg/controller/common/manage_children.go
@@ -267,7 +267,7 @@ func updateChildren(client *dynamicclientset.ResourceClient, updateStrategy Chil
 				}
 			case v1alpha1.ChildUpdateInPlace, v1alpha1.ChildUpdateRollingInPlace:
 				// Update the object in-place.
-				logging.Logger.Info("Updating", "parent", parent, "child", obj, "reason", "Recreate update strategy selected")
+				logging.Logger.Info("Updating", "parent", parent, "child", obj, "reason", "InPlace update strategy selected")
 				if _, err := client.Namespace(ns).Update(context.TODO(), newObj, metav1.UpdateOptions{}); err != nil {
 					switch {
 					case apierrors.IsNotFound(err):


### PR DESCRIPTION
Currently, regardless of whether a recreate (`ChildUpdateRecreate`/`ChildUpdateRollingRecreate`) or inplace update (`ChildUpdateInPlace`/`ChildUpdateRollingInPlace`) strategy is selected for updating children, the same message (`Recreate update strategy selected`) is shown in the log. Instead, they should print different messages.