### PR TITLE
refactor(common): #345 - Extract RelativeCommonMap to separate api package

### DIFF
--- a/pkg/controller/common/api/v1/common.go
+++ b/pkg/controller/common/api/v1/common.go
@@ -1,0 +1,162 @@
+package v1
+
+import (
+	"fmt"
+	"strings"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// RelativeObjectMap holds object related to given parent object.
+// The structure is [GroupVersionKind] -> [common.relativeName] -> *unstructured.Unstructured
+// where:
+//   GroupVersionKind - identifies type stored in entry
+//   relativeName() - return path to object in relation to parent
+//   *unstructured.Unstructured - object to store
+// i.e. :
+// "v1/Pod -> 'prometheus/Prometheus'" (for namespaced child resource if the parent is cluster scope)
+// "v1/Pod -> 'Prometheus'" (for namespaced child resource if parent is namespaced)
+// "v1/Namespace -> 'some'" (for cluster-scope child resource if parent is cluster scope)
+type RelativeObjectMap map[GroupVersionKind]map[string]*unstructured.Unstructured
+
+// InitGroup initializes a map for given schema.GroupVersionKind if not yet initialized
+func (m RelativeObjectMap) InitGroup(gvk schema.GroupVersionKind) {
+	internalGvk := GroupVersionKind{gvk}
+	if m[internalGvk] == nil {
+		m[internalGvk] = make(map[string]*unstructured.Unstructured)
+	}
+}
+
+// Insert inserts given obj to RelativeObjectMap regarding parent
+func (m RelativeObjectMap) Insert(parent v1.Object, obj *unstructured.Unstructured) {
+	internalGvk := GroupVersionKind{obj.GroupVersionKind()}
+	if m[internalGvk] == nil {
+		m.InitGroup(obj.GroupVersionKind())
+	}
+	group := m[internalGvk]
+	name := relativeName(parent, obj)
+	group[name] = obj
+}
+
+// InsertAll inserts given slice of objects to RelativeObjectMap regarding parent
+func (m RelativeObjectMap) InsertAll(parent v1.Object, objects []*unstructured.Unstructured) {
+	for _, object := range objects {
+		m.Insert(parent, object)
+	}
+}
+
+// FindGroupKindName search object by name in each schema.GroupKind (ignoring version part)
+func (m RelativeObjectMap) FindGroupKindName(gk schema.GroupKind, name string) *unstructured.Unstructured {
+	// The map is keyed by group-version-kind, but we don't know the version.
+	// So, check inside any GVK that matches the group and kind, ignoring version.
+	for key, objects := range m {
+		if key.GroupKind() == gk {
+			for n, object := range objects {
+				if n == name {
+					return object
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// relativeName returns the name of the object relative to the parent.
+// If the parent is cluster scoped and the object namespaced scoped the
+// name is of the format <namespace>/<name>. Otherwise, the name of the object
+// is returned.
+func relativeName(parent v1.Object, obj *unstructured.Unstructured) string {
+	if parent.GetNamespace() == "" && obj.GetNamespace() != "" {
+		return fmt.Sprintf("%s/%s", obj.GetNamespace(), obj.GetName())
+	}
+	return obj.GetName()
+}
+
+// ReplaceObjectIfExists replaces the object with the same name & namespace as
+// the given object with the contents of the given object. If no object exists
+// in the existing map then no action is taken.
+func (m RelativeObjectMap) ReplaceObjectIfExists(parent v1.Object, obj *unstructured.Unstructured) {
+	internalGvk := GroupVersionKind{obj.GroupVersionKind()}
+	objects := m[internalGvk]
+	if objects == nil {
+		// We only want to replace if it already exists, so do nothing.
+		return
+	}
+	name := relativeName(parent, obj)
+	if _, found := objects[name]; found {
+		objects[name] = obj
+	}
+}
+
+// List expands the RelativeObjectMap into a flat list of relative objects, in random order.
+func (m RelativeObjectMap) List() []*unstructured.Unstructured {
+	var list []*unstructured.Unstructured
+	for _, group := range m {
+		for _, obj := range group {
+			list = append(list, obj)
+		}
+	}
+	return list
+}
+
+// MakeRelativeObjectMap builds the map of objects resources that is suitable for use
+// in the `children` field of a CompositeController SyncRequest or
+// `attachments` field of  the  DecoratorControllers SyncRequest or `customize` field of
+// customize hook
+//
+// This function returns a RelativeObjectMap which is a map of maps. The outer most map
+// is keyed  using the object's type and the inner map is keyed using the
+// object's name. If the parent resource is clustered and the object resource
+// is namespaced the inner map's keys are prefixed by the namespace of the
+// object resource.
+//
+// This function requires parent resources has the meta.Namespace accurately
+// set. If the namespace of the parent is empty it's considered a clustered
+// resource.
+//
+// If a user returns a namespaced as a object of a clustered resources without
+// the namespace set this is considered a user error but it's not handled here
+// since the api errorstring to create the object is clear.
+func MakeRelativeObjectMap(parent v1.Object, list []*unstructured.Unstructured) RelativeObjectMap {
+	relativeObjects := make(RelativeObjectMap)
+
+	relativeObjects.InsertAll(parent, list)
+
+	return relativeObjects
+}
+
+// GroupVersionKind is metacontroller wrapper around schema.GroupVersionKind
+// implementing encoding.TextMarshaler and encoding.TextUnmarshaler
+type GroupVersionKind struct {
+	schema.GroupVersionKind
+}
+
+// MarshalText is implementation of  encoding.TextMarshaler
+func (gvk GroupVersionKind) MarshalText() ([]byte, error) {
+	var marshalledText string
+	if gvk.Group == "" {
+		marshalledText = fmt.Sprintf("%s.%s", gvk.Kind, gvk.Version)
+	} else {
+		marshalledText = fmt.Sprintf("%s.%s/%s", gvk.Kind, gvk.Group, gvk.Version)
+	}
+	return []byte(marshalledText), nil
+}
+
+// UnmarshalText is implementation of encoding.TextUnmarshaler
+func (gvk *GroupVersionKind) UnmarshalText(text []byte) error {
+	kindGroupVersionString := string(text)
+	parts := strings.SplitN(kindGroupVersionString, ".", 2)
+	if len(parts) < 2 {
+		return fmt.Errorf("could not unmarshall [%s], expected string in 'kind.group/version' format", string(text))
+	}
+	groupVersion, err := schema.ParseGroupVersion(parts[1])
+	if err != nil {
+		return err
+	}
+	*gvk = GroupVersionKind{
+		groupVersion.WithKind(parts[0]),
+	}
+	return nil
+}

--- a/pkg/controller/common/api/v1/common_test.go
+++ b/pkg/controller/common/api/v1/common_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Metacontroller authors.
+Copyright 2022 Metacontroller authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,17 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package common
+package v1
 
 import (
 	"reflect"
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -84,7 +82,7 @@ func TestGroupVersionKind_UnmrshalTextWithException(t *testing.T) {
 	}
 }
 
-func TestChildMap_InitGroup_ShouldInitializeNilGroup(t *testing.T) {
+func TestRelativeObjectMap_InitGroup_ShouldInitializeNilGroup(t *testing.T) {
 	underTest := make(RelativeObjectMap)
 	gvk := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "StatefulSet"}
 
@@ -97,7 +95,7 @@ func TestChildMap_InitGroup_ShouldInitializeNilGroup(t *testing.T) {
 	}
 }
 
-func TestChildMap_InitGroup_ShouldNotOverrideNonNilGroup(t *testing.T) {
+func TestRelativeObjectMap_InitGroup_ShouldNotOverrideNonNilGroup(t *testing.T) {
 	underTest := make(RelativeObjectMap)
 	gvk := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "StatefulSet"}
 	internalGvk := GroupVersionKind{gvk}
@@ -113,14 +111,14 @@ func TestChildMap_InitGroup_ShouldNotOverrideNonNilGroup(t *testing.T) {
 	}
 }
 
-func TestChildMap_RelativeName_SameNamespace(t *testing.T) {
-	parent := v1.Pod{
+func TestRelativeObjectMap_RelativeName_SameNamespace(t *testing.T) {
+	parent := corev1.Pod{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "ss",
 		},
-		Spec:   v1.PodSpec{},
-		Status: v1.PodStatus{},
+		Spec:   corev1.PodSpec{},
+		Status: corev1.PodStatus{},
 	}
 	object := &unstructured.Unstructured{}
 	object.SetNamespace("ss")
@@ -134,14 +132,14 @@ func TestChildMap_RelativeName_SameNamespace(t *testing.T) {
 	}
 }
 
-func TestChildMap_RelativeName_ClusteredParent(t *testing.T) {
-	parent := v1.Pod{
+func TestRelativeObjectMap_RelativeName_ClusteredParent(t *testing.T) {
+	parent := corev1.Pod{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "",
 		},
-		Spec:   v1.PodSpec{},
-		Status: v1.PodStatus{},
+		Spec:   corev1.PodSpec{},
+		Status: corev1.PodStatus{},
 	}
 	object := &unstructured.Unstructured{}
 	object.SetNamespace("some")
@@ -155,14 +153,14 @@ func TestChildMap_RelativeName_ClusteredParent(t *testing.T) {
 	}
 }
 
-func TestChildMap_RelativeName_BothClustered(t *testing.T) {
-	parent := v1.Pod{
+func TestRelativeObjectMap_RelativeName_BothClustered(t *testing.T) {
+	parent := corev1.Pod{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "",
 		},
-		Spec:   v1.PodSpec{},
-		Status: v1.PodStatus{},
+		Spec:   corev1.PodSpec{},
+		Status: corev1.PodStatus{},
 	}
 	object := &unstructured.Unstructured{}
 	object.SetNamespace("")

--- a/pkg/controller/common/common.go
+++ b/pkg/controller/common/common.go
@@ -40,7 +40,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/tools/cache"
 
@@ -137,160 +136,12 @@ func (controllerContext ControllerContext) Start() {
 	controllerContext.McInformerFactory.Start(nil)
 }
 
-// GroupVersionKind is metacontroller wrapper around schema.GroupVersionKind
-// implementing encoding.TextMarshaler and encoding.TextUnmarshaler
-type GroupVersionKind struct {
-	schema.GroupVersionKind
-}
-
-// MarshalText is implementation of  encoding.TextMarshaler
-func (gvk GroupVersionKind) MarshalText() ([]byte, error) {
-	var marshalledText string
-	if gvk.Group == "" {
-		marshalledText = fmt.Sprintf("%s.%s", gvk.Kind, gvk.Version)
-	} else {
-		marshalledText = fmt.Sprintf("%s.%s/%s", gvk.Kind, gvk.Group, gvk.Version)
-	}
-	return []byte(marshalledText), nil
-}
-
-// UnmarshalText is implementation of encoding.TextUnmarshaler
-func (gvk *GroupVersionKind) UnmarshalText(text []byte) error {
-	kindGroupVersionString := string(text)
-	parts := strings.SplitN(kindGroupVersionString, ".", 2)
-	if len(parts) < 2 {
-		return fmt.Errorf("could not unmarshall [%s], expected string in 'kind.group/version' format", string(text))
-	}
-	groupVersion, err := schema.ParseGroupVersion(parts[1])
-	if err != nil {
-		return err
-	}
-	*gvk = GroupVersionKind{
-		groupVersion.WithKind(parts[0]),
-	}
-	return nil
-}
-
-// RelativeObjectMap holds object related to given parent object.
-// The structure is [GroupVersionKind] -> [common.relativeName] -> *unstructured.Unstructured
-// where:
-//   GroupVersionKind - identifies type stored in entry
-//   relativeName() - return path to object in relation to parent
-//   *unstructured.Unstructured - object to store
-type RelativeObjectMap map[GroupVersionKind]map[string]*unstructured.Unstructured
-
-// InitGroup initializes a map for given schema.GroupVersionKind if not yet initialized
-func (m RelativeObjectMap) InitGroup(gvk schema.GroupVersionKind) {
-	internalGvk := GroupVersionKind{gvk}
-	if m[internalGvk] == nil {
-		m[internalGvk] = make(map[string]*unstructured.Unstructured)
-	}
-}
-
-// Insert inserts given obj to RelativeObjectMap regarding parent
-func (m RelativeObjectMap) Insert(parent metav1.Object, obj *unstructured.Unstructured) {
-	internalGvk := GroupVersionKind{obj.GroupVersionKind()}
-	if m[internalGvk] == nil {
-		m.InitGroup(obj.GroupVersionKind())
-	}
-	group := m[internalGvk]
-	name := relativeName(parent, obj)
-	group[name] = obj
-}
-
-// InsertAll inserts given slice of objects to RelativeObjectMap regarding parent
-func (m RelativeObjectMap) InsertAll(parent metav1.Object, objects []*unstructured.Unstructured) {
-	for _, object := range objects {
-		m.Insert(parent, object)
-	}
-}
-
-// FindGroupKindName search object by name in each schema.GroupKind (ignoring version part)
-func (m RelativeObjectMap) FindGroupKindName(gk schema.GroupKind, name string) *unstructured.Unstructured {
-	// The map is keyed by group-version-kind, but we don't know the version.
-	// So, check inside any GVK that matches the group and kind, ignoring version.
-	for key, objects := range m {
-		if key.GroupKind() == gk {
-			for n, object := range objects {
-				if n == name {
-					return object
-				}
-			}
-		}
-	}
-	return nil
-}
-
-// relativeName returns the name of the object relative to the parent.
-// If the parent is cluster scoped and the object namespaced scoped the
-// name is of the format <namespace>/<name>. Otherwise the name of the object
-// is returned.
-func relativeName(parent metav1.Object, obj *unstructured.Unstructured) string {
-	if parent.GetNamespace() == "" && obj.GetNamespace() != "" {
-		return fmt.Sprintf("%s/%s", obj.GetNamespace(), obj.GetName())
-	}
-	return obj.GetName()
-}
-
 // describeObject returns a human-readable string to identify a given object.
 func describeObject(obj *unstructured.Unstructured) string {
 	if ns := obj.GetNamespace(); ns != "" {
 		return fmt.Sprintf("%s %s/%s", obj.GetKind(), ns, obj.GetName())
 	}
 	return fmt.Sprintf("%s %s", obj.GetKind(), obj.GetName())
-}
-
-// ReplaceObject replaces the object with the same name & namespace as
-// the given object with the contents of the given object. If no object exists
-// in the existing map then no action is taken.
-func (m RelativeObjectMap) ReplaceObject(parent metav1.Object, obj *unstructured.Unstructured) {
-	internalGvk := GroupVersionKind{obj.GroupVersionKind()}
-	objects := m[internalGvk]
-	if objects == nil {
-		// We only want to replace if it already exists, so do nothing.
-		return
-	}
-	name := relativeName(parent, obj)
-	if _, found := objects[name]; found {
-		objects[name] = obj
-	}
-}
-
-// List expands the RelativeObjectMap into a flat list of relative objects, in random order.
-func (m RelativeObjectMap) List() []*unstructured.Unstructured {
-	var list []*unstructured.Unstructured
-	for _, group := range m {
-		for _, obj := range group {
-			list = append(list, obj)
-		}
-	}
-	return list
-}
-
-// MakeRelativeObjectMap builds the map of objects resources that is suitable for use
-// in the `children` field of a CompositeController SyncRequest or
-// `attachments` field of  the  DecoratorControllers SyncRequest or `customize` field of
-// customize hook
-//
-// This function returns a RelativeObjectMap which is a map of maps. The outer most map
-// is keyed  using the object's type and the inner map is keyed using the
-// object's name. If the parent resource is clustered and the object resource
-// is namespaced the inner map's keys are prefixed by the namespace of the
-// object resource.
-//
-// This function requires parent resources has the meta.Namespace accurately
-// set. If the namespace of the parent is empty it's considered a clustered
-// resource.
-//
-// If a user returns a namespaced as a object of a clustered resources without
-// the namespace set this is considered a user error but it's not handled here
-// since the api errorstring to create the object is clear.
-func MakeRelativeObjectMap(parent metav1.Object, list []*unstructured.Unstructured) RelativeObjectMap {
-	relativeObjects := make(RelativeObjectMap)
-
-	relativeObjects.InsertAll(parent, list)
-
-	return relativeObjects
 }
 
 func ParseAPIVersion(apiVersion string) (group, version string) {

--- a/pkg/controller/common/customize/manager.go
+++ b/pkg/controller/common/customize/manager.go
@@ -18,6 +18,7 @@ package customize
 
 import (
 	"fmt"
+	commonv1 "metacontroller/pkg/controller/common/api/v1"
 	v1 "metacontroller/pkg/controller/common/customize/api/v1"
 	"metacontroller/pkg/hooks"
 
@@ -333,8 +334,8 @@ func listObjects(selector labels.Selector, namespace string, informer *dynamicin
 	return informer.Lister().List(selector)
 }
 
-func (rm *Manager) GetRelatedObjects(parent *unstructured.Unstructured) (common.RelativeObjectMap, error) {
-	childMap := make(common.RelativeObjectMap)
+func (rm *Manager) GetRelatedObjects(parent *unstructured.Unstructured) (commonv1.RelativeObjectMap, error) {
+	childMap := make(commonv1.RelativeObjectMap)
 	if !rm.IsEnabled() {
 		return childMap, nil
 	}

--- a/pkg/controller/common/manage_children.go
+++ b/pkg/controller/common/manage_children.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	commonv1 "metacontroller/pkg/controller/common/api/v1"
 	"metacontroller/pkg/logging"
 	"reflect"
 
@@ -128,7 +129,7 @@ type ChildUpdateStrategy interface {
 	GetMethod(apiGroup, kind string) v1alpha1.ChildUpdateMethod
 }
 
-func ManageChildren(dynClient *dynamicclientset.Clientset, updateStrategy ChildUpdateStrategy, parent *unstructured.Unstructured, observedChildren, desiredChildren RelativeObjectMap) error {
+func ManageChildren(dynClient *dynamicclientset.Clientset, updateStrategy ChildUpdateStrategy, parent *unstructured.Unstructured, observedChildren, desiredChildren commonv1.RelativeObjectMap) error {
 	// If some operations fail, keep trying others so, for example,
 	// we don't block recovery (create new Pod) on a failed delete.
 	var errs []error

--- a/pkg/controller/common/manage_children_test.go
+++ b/pkg/controller/common/manage_children_test.go
@@ -18,6 +18,7 @@ package common
 
 import (
 	"metacontroller/pkg/apis/metacontroller/v1alpha1"
+	commonv1 "metacontroller/pkg/controller/common/api/v1"
 	dynamicclientset "metacontroller/pkg/dynamic/clientset"
 	. "metacontroller/pkg/internal/testutils/common"
 	. "metacontroller/pkg/internal/testutils/dynamic/clientset"
@@ -117,8 +118,8 @@ func TestManageChildren(t *testing.T) {
 		dynClient        func() *dynamicclientset.Clientset
 		updateStrategy   ChildUpdateStrategy
 		parent           *unstructured.Unstructured
-		observedChildren RelativeObjectMap
-		desiredChildren  RelativeObjectMap
+		observedChildren commonv1.RelativeObjectMap
+		desiredChildren  commonv1.RelativeObjectMap
 	}
 
 	unstructuredDefault := NewDefaultUnstructured()
@@ -141,7 +142,7 @@ func TestManageChildren(t *testing.T) {
 				},
 				updateStrategy: childUpdateOnDeleteStrategy{},
 				parent:         unstructuredDefault,
-				observedChildren: MakeRelativeObjectMap(
+				observedChildren: commonv1.MakeRelativeObjectMap(
 					unstructuredDefault,
 					unstructuredDefaultList,
 				),
@@ -163,7 +164,7 @@ func TestManageChildren(t *testing.T) {
 				},
 				updateStrategy: childUpdateOnDeleteStrategy{},
 				parent:         unstructuredDefault,
-				observedChildren: MakeRelativeObjectMap(
+				observedChildren: commonv1.MakeRelativeObjectMap(
 					unstructuredDefault,
 					unstructuredDefaultList,
 				),
@@ -185,11 +186,11 @@ func TestManageChildren(t *testing.T) {
 				},
 				updateStrategy: childUpdateRecreateStrategy{},
 				parent:         unstructuredDefault,
-				observedChildren: MakeRelativeObjectMap(
+				observedChildren: commonv1.MakeRelativeObjectMap(
 					unstructuredDefault,
 					unstructuredDefaultList,
 				),
-				desiredChildren: MakeRelativeObjectMap(
+				desiredChildren: commonv1.MakeRelativeObjectMap(
 					unstructuredDefault,
 					unstructuredDefaultList,
 				),
@@ -207,11 +208,11 @@ func TestManageChildren(t *testing.T) {
 				},
 				updateStrategy: childUpdateRecreateStrategy{},
 				parent:         unstructuredDefault,
-				observedChildren: MakeRelativeObjectMap(
+				observedChildren: commonv1.MakeRelativeObjectMap(
 					unstructuredDefault,
 					unstructuredDefaultList,
 				),
-				desiredChildren: MakeRelativeObjectMap(
+				desiredChildren: commonv1.MakeRelativeObjectMap(
 					unstructuredDefault,
 					unstructuredDefaultList,
 				),
@@ -230,7 +231,7 @@ func TestManageChildren(t *testing.T) {
 				},
 				updateStrategy: childUpdateOnDeleteStrategy{},
 				parent:         unstructuredDefault,
-				observedChildren: MakeRelativeObjectMap(
+				observedChildren: commonv1.MakeRelativeObjectMap(
 					unstructuredDefault,
 					unstructuredDefaultList,
 				),
@@ -247,11 +248,11 @@ func TestManageChildren(t *testing.T) {
 				},
 				updateStrategy: childUpdateInPlaceStrategy{},
 				parent:         unstructuredDefault,
-				observedChildren: MakeRelativeObjectMap(
+				observedChildren: commonv1.MakeRelativeObjectMap(
 					unstructuredDefault,
 					unstructuredDefaultList,
 				),
-				desiredChildren: MakeRelativeObjectMap(
+				desiredChildren: commonv1.MakeRelativeObjectMap(
 					unstructuredDefault,
 					unstructuredDefaultList,
 				),
@@ -272,11 +273,11 @@ func TestManageChildren(t *testing.T) {
 				},
 				updateStrategy: childUpdateInPlaceStrategy{},
 				parent:         unstructuredDefault,
-				observedChildren: MakeRelativeObjectMap(
+				observedChildren: commonv1.MakeRelativeObjectMap(
 					unstructuredDefault,
 					unstructuredDefaultList,
 				),
-				desiredChildren: MakeRelativeObjectMap(
+				desiredChildren: commonv1.MakeRelativeObjectMap(
 					unstructuredDefault,
 					unstructuredDefaultList,
 				),
@@ -297,11 +298,11 @@ func TestManageChildren(t *testing.T) {
 				},
 				updateStrategy: childUpdateInPlaceStrategy{},
 				parent:         unstructuredDefault,
-				observedChildren: MakeRelativeObjectMap(
+				observedChildren: commonv1.MakeRelativeObjectMap(
 					unstructuredDefault,
 					unstructuredDefaultList,
 				),
-				desiredChildren: MakeRelativeObjectMap(
+				desiredChildren: commonv1.MakeRelativeObjectMap(
 					unstructuredDefault,
 					unstructuredDefaultList,
 				),
@@ -319,11 +320,11 @@ func TestManageChildren(t *testing.T) {
 				},
 				updateStrategy: childUpdateInPlaceStrategy{},
 				parent:         unstructuredDefault,
-				observedChildren: MakeRelativeObjectMap(
+				observedChildren: commonv1.MakeRelativeObjectMap(
 					unstructuredDefault,
 					unstructuredDefaultList,
 				),
-				desiredChildren: MakeRelativeObjectMap(
+				desiredChildren: commonv1.MakeRelativeObjectMap(
 					unstructuredDefault,
 					unstructuredDefaultList,
 				),
@@ -346,7 +347,7 @@ func TestManageChildren(t *testing.T) {
 				updateStrategy:   childUpdateInPlaceStrategy{},
 				parent:           unstructuredDefault,
 				observedChildren: nil,
-				desiredChildren: MakeRelativeObjectMap(
+				desiredChildren: commonv1.MakeRelativeObjectMap(
 					unstructuredDefault,
 					unstructuredDefaultList,
 				),
@@ -365,7 +366,7 @@ func TestManageChildren(t *testing.T) {
 				updateStrategy:   childUpdateOnDeleteStrategy{},
 				parent:           unstructuredDefault,
 				observedChildren: nil,
-				desiredChildren: MakeRelativeObjectMap(
+				desiredChildren: commonv1.MakeRelativeObjectMap(
 					unstructuredDefault,
 					unstructuredDefaultList,
 				),

--- a/pkg/controller/composite/api/v1/hooks.go
+++ b/pkg/controller/composite/api/v1/hooks.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"metacontroller/pkg/apis/metacontroller/v1alpha1"
-	"metacontroller/pkg/controller/common"
+	v1 "metacontroller/pkg/controller/common/api/v1"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -11,8 +11,8 @@ import (
 type SyncHookRequest struct {
 	Controller *v1alpha1.CompositeController `json:"controller"`
 	Parent     *unstructured.Unstructured    `json:"parent"`
-	Children   common.RelativeObjectMap      `json:"children"`
-	Related    common.RelativeObjectMap      `json:"related"`
+	Children   v1.RelativeObjectMap          `json:"children"`
+	Related    v1.RelativeObjectMap          `json:"related"`
 	Finalizing bool                          `json:"finalizing"`
 }
 

--- a/pkg/controller/composite/controller.go
+++ b/pkg/controller/composite/controller.go
@@ -19,6 +19,7 @@ package composite
 import (
 	"context"
 	"fmt"
+	commonv1 "metacontroller/pkg/controller/common/api/v1"
 	"metacontroller/pkg/hooks"
 	"metacontroller/pkg/logging"
 	"reflect"
@@ -530,7 +531,7 @@ func (pc *parentController) syncParentObject(parent *unstructured.Unstructured) 
 	if err != nil {
 		return err
 	}
-	desiredChildren := common.MakeRelativeObjectMap(parent, syncResult.Children)
+	desiredChildren := commonv1.MakeRelativeObjectMap(parent, syncResult.Children)
 
 	// Enqueue a delayed resync, if requested.
 	if syncResult.ResyncAfterSeconds > 0 {
@@ -658,7 +659,7 @@ func (pc *parentController) canAdoptFunc(parent *unstructured.Unstructured) func
 	})
 }
 
-func (pc *parentController) claimChildren(parent *unstructured.Unstructured) (common.RelativeObjectMap, error) {
+func (pc *parentController) claimChildren(parent *unstructured.Unstructured) (commonv1.RelativeObjectMap, error) {
 	// Set up values common to all child types.
 	parentNamespace := parent.GetNamespace()
 	parentGVK := pc.parentResource.GroupVersionKind()
@@ -669,7 +670,7 @@ func (pc *parentController) claimChildren(parent *unstructured.Unstructured) (co
 	canAdoptFunc := pc.canAdoptFunc(parent)
 
 	// Claim all child types.
-	childMap := make(common.RelativeObjectMap)
+	childMap := make(commonv1.RelativeObjectMap)
 	for _, child := range pc.cc.Spec.ChildResources {
 		// List all objects of the child kind in the parent object's namespace,
 		// or in all namespaces if the parent is cluster-scoped.

--- a/pkg/controller/composite/controller_revision.go
+++ b/pkg/controller/composite/controller_revision.go
@@ -21,6 +21,7 @@ import (
 	"crypto/sha1" // #nosec
 	"encoding/hex"
 	"fmt"
+	v12 "metacontroller/pkg/controller/common/api/v1"
 	v1 "metacontroller/pkg/controller/composite/api/v1"
 	"metacontroller/pkg/logging"
 	"reflect"
@@ -76,7 +77,7 @@ func (pc *parentController) claimRevisions(parent *unstructured.Unstructured) ([
 	return revisions, nil
 }
 
-func (pc *parentController) syncRevisions(parent *unstructured.Unstructured, observedChildren common.RelativeObjectMap, relatedObjects common.RelativeObjectMap) (*v1.SyncHookResponse, error) {
+func (pc *parentController) syncRevisions(parent *unstructured.Unstructured, observedChildren v12.RelativeObjectMap, relatedObjects v12.RelativeObjectMap) (*v1.SyncHookResponse, error) {
 	// If no child resources use rolling updates, just sync the latest parent.
 	// Also, if the parent object is being deleted and we don't have a finalizer,
 	// just sync the latest parent to get the status since we won't manage
@@ -170,7 +171,7 @@ func (pc *parentController) syncRevisions(parent *unstructured.Unstructured, obs
 				return
 			}
 			pr.syncResult = syncResult
-			pr.desiredChildMap = common.MakeRelativeObjectMap(parent, syncResult.Children)
+			pr.desiredChildMap = v12.MakeRelativeObjectMap(parent, syncResult.Children)
 		}(pr)
 	}
 	wg.Wait()
@@ -220,7 +221,7 @@ func (pc *parentController) syncRevisions(parent *unstructured.Unstructured, obs
 						Kind:  ck.Kind},
 					name)
 				if child != nil {
-					desiredChildren.ReplaceObject(parent, child)
+					desiredChildren.ReplaceObjectIfExists(parent, child)
 				}
 			}
 		}
@@ -420,7 +421,7 @@ type parentRevision struct {
 	syncResult *v1.SyncHookResponse
 	syncError  error
 
-	desiredChildMap common.RelativeObjectMap
+	desiredChildMap v12.RelativeObjectMap
 }
 
 func (pr *parentRevision) countChildren() int {

--- a/pkg/controller/composite/hooks_test.go
+++ b/pkg/controller/composite/hooks_test.go
@@ -2,12 +2,12 @@ package composite
 
 import (
 	"metacontroller/pkg/apis/metacontroller/v1alpha1"
-	"metacontroller/pkg/controller/common"
+	v1 "metacontroller/pkg/controller/common/api/v1"
 	composite "metacontroller/pkg/controller/composite/api/v1"
 	"metacontroller/pkg/internal/testutils/hooks"
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/nsf/jsondiff"
 
@@ -47,14 +47,14 @@ func TestSyncHookRequest_MarshalJSON(t *testing.T) {
   "finalizing": false
 }`
 
-	children := make(common.RelativeObjectMap)
-	parent := v1.Pod{
+	children := make(v1.RelativeObjectMap)
+	parent := corev1.Pod{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "some",
 		},
-		Spec:   v1.PodSpec{},
-		Status: v1.PodStatus{},
+		Spec:   corev1.PodSpec{},
+		Status: corev1.PodStatus{},
 	}
 
 	child := &unstructured.Unstructured{}
@@ -72,7 +72,7 @@ func TestSyncHookRequest_MarshalJSON(t *testing.T) {
 		},
 		Parent:     &unstructured.Unstructured{},
 		Children:   children,
-		Related:    make(common.RelativeObjectMap),
+		Related:    make(v1.RelativeObjectMap),
 		Finalizing: false,
 	}
 

--- a/pkg/controller/composite/rolling_update.go
+++ b/pkg/controller/composite/rolling_update.go
@@ -18,6 +18,7 @@ package composite
 
 import (
 	"fmt"
+	v1 "metacontroller/pkg/controller/common/api/v1"
 	"reflect"
 
 	"metacontroller/pkg/controller/common"
@@ -31,7 +32,7 @@ import (
 	dynamicobject "metacontroller/pkg/dynamic/object"
 )
 
-func (pc *parentController) syncRollingUpdate(parentRevisions []*parentRevision, observedChildren common.RelativeObjectMap) error {
+func (pc *parentController) syncRollingUpdate(parentRevisions []*parentRevision, observedChildren v1.RelativeObjectMap) error {
 	// Reconcile the set of existing child claims in ControllerRevisions.
 	claimed := pc.syncRevisionClaims(parentRevisions)
 
@@ -157,7 +158,7 @@ func (pc *parentController) syncRollingUpdate(parentRevisions []*parentRevision,
 	return nil
 }
 
-func (pc *parentController) shouldContinueRolling(latest *parentRevision, observedChildren common.RelativeObjectMap) error {
+func (pc *parentController) shouldContinueRolling(latest *parentRevision, observedChildren v1.RelativeObjectMap) error {
 	// We continue rolling only if all children claimed by the latest revision
 	// are updated and were observed in a "happy" state, according to the
 	// user-supplied, resource-specific status checks.

--- a/pkg/controller/decorator/api/v1/hooks.go
+++ b/pkg/controller/decorator/api/v1/hooks.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"metacontroller/pkg/apis/metacontroller/v1alpha1"
-	"metacontroller/pkg/controller/common"
+	v1 "metacontroller/pkg/controller/common/api/v1"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -11,8 +11,8 @@ import (
 type SyncHookRequest struct {
 	Controller  *v1alpha1.DecoratorController `json:"controller"`
 	Object      *unstructured.Unstructured    `json:"object"`
-	Attachments common.RelativeObjectMap      `json:"attachments"`
-	Related     common.RelativeObjectMap      `json:"related"`
+	Attachments v1.RelativeObjectMap          `json:"attachments"`
+	Related     v1.RelativeObjectMap          `json:"related"`
 	Finalizing  bool                          `json:"finalizing"`
 }
 

--- a/pkg/controller/decorator/controller.go
+++ b/pkg/controller/decorator/controller.go
@@ -19,6 +19,7 @@ package decorator
 import (
 	"context"
 	"fmt"
+	commonv1 "metacontroller/pkg/controller/common/api/v1"
 	v1 "metacontroller/pkg/controller/decorator/api/v1"
 	"metacontroller/pkg/hooks"
 	"reflect"
@@ -549,7 +550,7 @@ func (c *decoratorController) syncParentObject(parent *unstructured.Unstructured
 	if err != nil {
 		return err
 	}
-	desiredChildren := common.MakeRelativeObjectMap(parent, syncResult.Attachments)
+	desiredChildren := commonv1.MakeRelativeObjectMap(parent, syncResult.Attachments)
 
 	// Enqueue a delayed resync, if requested.
 	if syncResult.ResyncAfterSeconds > 0 {
@@ -663,10 +664,10 @@ func (c *decoratorController) syncParentObject(parent *unstructured.Unstructured
 	return manageErr
 }
 
-func (c *decoratorController) getChildren(parent *unstructured.Unstructured) (common.RelativeObjectMap, error) {
+func (c *decoratorController) getChildren(parent *unstructured.Unstructured) (commonv1.RelativeObjectMap, error) {
 	parentUID := parent.GetUID()
 	parentNamespace := parent.GetNamespace()
-	childMap := make(common.RelativeObjectMap)
+	childMap := make(commonv1.RelativeObjectMap)
 
 	for _, child := range c.dc.Spec.Attachments {
 		// List all objects of the child kind in the parent object's namespace,


### PR DESCRIPTION
Second part of extracting, this time common map object used to storing relative members.

