### PR TITLE
refactor(clientset): Use controller-runtime client to modify objects

### DIFF
--- a/pkg/controller/composite/metacontroller.go
+++ b/pkg/controller/composite/metacontroller.go
@@ -166,6 +166,7 @@ func (mc *Metacontroller) reconcileCompositeController(cc *v1alpha1.CompositeCon
 	}
 
 	pc, err := newParentController(
+		mc.k8sClient,
 		mc.resources,
 		mc.dynClient,
 		mc.dynInformers,

--- a/pkg/controller/decorator/metacontroller.go
+++ b/pkg/controller/decorator/metacontroller.go
@@ -126,6 +126,7 @@ func (mc *Metacontroller) reconcileDecoratorController(dc *v1alpha1.DecoratorCon
 	}
 
 	c, err := newDecoratorController(
+		mc.k8sClient,
 		mc.resources,
 		mc.dynClient,
 		mc.dynInformers,

--- a/pkg/internal/testutils/common/util.go
+++ b/pkg/internal/testutils/common/util.go
@@ -19,6 +19,7 @@ package common
 import (
 	"metacontroller/pkg/controller/common/finalizer"
 	dynamicdiscovery "metacontroller/pkg/dynamic/discovery"
+	fakeCtrlRuntime "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/tools/record"
@@ -31,7 +32,7 @@ func NewCh() chan struct{} {
 
 var NoOpFn = func(fakeDynamicClient *fake.FakeDynamicClient) {}
 
-var DefaultFinalizerManager = finalizer.NewManager("testFinalizerManager", false)
+var DefaultFinalizerManager = finalizer.NewManager(fakeCtrlRuntime.NewClientBuilder().Build(), "testFinalizerManager", false)
 
 var DefaultApiResource = dynamicdiscovery.APIResource{
 	APIResource: NewDefaultAPIResource(),


### PR DESCRIPTION
Long term plan is to drop dependency on `metacontroller` dynamic clienset.

One change is that we will use cache to `Get` , so objects can be  a bit stale, question is if it is a big problem.