### PR TITLE
docs: fix how port for metrics is passed

### DIFF
--- a/docs/src/guide/configuration.md
+++ b/docs/src/guide/configuration.md
@@ -18,7 +18,7 @@ in `manifests/metacontroller.yaml`):
 | `--zap-stacktrace-level` | Zap Level at and above which stacktraces are captured - one of `info` or `error` (e.g. `--zap-stacktrace-level='info'`). |
 | `--discovery-interval` | How often to refresh discovery cache to pick up newly-installed resources (e.g. `--discovery-interval=10s`). |
 | `--cache-flush-interval` | How often to flush local caches and relist objects from the API server (e.g. `--cache-flush-interval=30m`). |
-| `--metrics-address` | The address to bind metrics endpoint - /metrics (e.g. `--metrics-address=":9999"`). It can be set to "0" to disable the metrics serving. |
+| `--metrics-address` | The address to bind metrics endpoint - /metrics (e.g. `--metrics-address=:9999`). It can be set to "0" to disable the metrics serving. |
 | `--kubeconfig` | Path to kubeconfig file (same format as used by kubectl); if not specified, use in-cluster config (e.g. `--kubeconfig=/path/to/kubeconfig`). |
 | `--client-go-qps` | Number of queries per second client-go is allowed to make (default 5, e.g. `--client-go-qps=100`) |
 | `--client-go-burst` | Allowed burst queries for client-go (default 10, e.g. `--client-go-burst=200`) |


### PR DESCRIPTION
Attempting to pass the option as suggested in the doc (with quotes) results in an error on bootup (and subsequent `CrashLoopBackOff`):

```
{"level":"info","ts":1644413896.8420408,"logger":"controller-runtime.metrics","msg":"metrics server is starting to listen","addr":"\":9999\""}
{"level":"error","ts":1644413896.8425508,"logger":"controller-runtime.metrics","msg":"metrics server failed to listen. You may want to disable the metrics server or use another port if it is due to conflicts","error":"error listening on \":9999\": listen tcp: address tcp/9999\": unknown port","stacktrace":"sigs.k8s.io/controller-runtime/pkg/metrics.NewListener\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.5/pkg/metrics/listener.go:48\nsigs.k8s.io/controller-runtime/pkg/manager.New\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.5/pkg/manager/manager.go:353\nmetacontroller/pkg/server.New\n\t/go/src/metacontroller/pkg/server/server.go:55\nmain.main\n\t/go/src/metacontroller/main.go:83\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:255"}
{"level":"error","ts":1644413896.842614,"msg":"Terminating","error":"error listening on \":9999\": listen tcp: address tcp/9999\": unknown port","stacktrace":"runtime.main\n\t/usr/local/go/src/runtime/proc.go:255"}
```

Instead, port should be passed without quotes.