### PR TITLE
feat(helm): implement pod disruption budget

### DIFF
--- a/deploy/helm/metacontroller/ci/pdb-value.yaml
+++ b/deploy/helm/metacontroller/ci/pdb-value.yaml
@@ -76,6 +76,7 @@ clusterRole:
       - "*"
 
 # podDisruptionBudget which can be enabled when running more then one replica's
-podDisruptionBudget: {}
-  # minAvailable: 1
-  # maxUnavailable: 0
+podDisruptionBudget:
+  minAvailable: 1
+
+replicas: 2

--- a/deploy/helm/metacontroller/templates/pdb.yaml
+++ b/deploy/helm/metacontroller/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.podDisruptionBudget (gt (.Values.replicas | int) 1) }}
+apiVersion: {{ ternary "policy/v1" "policy/v1beta1" (semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version) }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "metacontroller.fullname" . }}
+  labels:
+    {{- include "metacontroller.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "metacontroller.selectorLabels" . | nindent 6 }}
+    {{- if .Values.podDisruptionBudget.minAvailable }}
+    minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+    {{- end }}
+    {{- if .Values.podDisruptionBudget.maxUnavailable }}
+    maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+    {{- end }}
+{{- end -}}

--- a/docs/src/guide/helm-install.md
+++ b/docs/src/guide/helm-install.md
@@ -57,3 +57,4 @@ as OCI is currently (at least for helm 3.8.x) a beta feature.
 | `priorityClassName`                       | The name of the `PriorityClass` that will be assigned to metacontroller | `""`                          |
 | `clusterRole.aggregationRule`             | The `aggregationRule` applied to metacontroller `ClusterRole` | `{}`                                    |
 | `clusterRole.rules`                       | The `rules` applied to metacontroller `ClusterRole` | ```{ "apiGroups": "*", "resources": "*", "verbs": "*" }``` |
+| `podDisruptionBudget`                     | The `podDisruptionBudget` applied to metacontroller `pods` |  `{}`                                      |


### PR DESCRIPTION
Signed-off-by: Roel van den Berg <roel.vandenberg@infosupport.com>

I have implemented a Pod Disruption Budget for the controller pods so that we can guarantee that there is allways a pod online when running in a HA setup.

