### PR TITLE
refactor(equality): #155 - Extract equality as separate function

### DIFF
--- a/pkg/controller/common/equality.go
+++ b/pkg/controller/common/equality.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2022 Metacontroller authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"reflect"
+)
+
+// DeepEqual compares two objects for equality
+func DeepEqual(left, right interface{}) bool {
+	return reflect.DeepEqual(left, right)
+}

--- a/pkg/controller/common/manage_children.go
+++ b/pkg/controller/common/manage_children.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	commonv1 "metacontroller/pkg/controller/common/api/v1"
 	"metacontroller/pkg/logging"
-	"reflect"
 
 	"k8s.io/utils/pointer"
 
@@ -215,7 +214,7 @@ func updateChildren(client *dynamicclientset.ResourceClient, updateStrategy Chil
 			}
 
 			// Attempt an update, if the 3-way merge resulted in any changes.
-			if reflect.DeepEqual(newObj.UnstructuredContent(), oldObj.UnstructuredContent()) {
+			if DeepEqual(newObj.UnstructuredContent(), oldObj.UnstructuredContent()) {
 				// Nothing changed.
 				continue
 			}

--- a/pkg/controller/composite/controller.go
+++ b/pkg/controller/composite/controller.go
@@ -22,7 +22,6 @@ import (
 	commonv1 "metacontroller/pkg/controller/common/api/v1"
 	"metacontroller/pkg/hooks"
 	"metacontroller/pkg/logging"
-	"reflect"
 	"sync"
 	"time"
 
@@ -724,7 +723,7 @@ func (pc *parentController) updateParentStatus(parent *unstructured.Unstructured
 	// We can't use Patch() because we need to ensure that the UID matches.
 	return pc.parentClient.Namespace(parent.GetNamespace()).AtomicStatusUpdate(parent, func(obj *unstructured.Unstructured) bool {
 		oldStatus := obj.UnstructuredContent()["status"]
-		if reflect.DeepEqual(oldStatus, status) {
+		if common.DeepEqual(oldStatus, status) {
 			// Nothing to do.
 			return false
 		}

--- a/pkg/controller/composite/controller_revision.go
+++ b/pkg/controller/composite/controller_revision.go
@@ -24,7 +24,6 @@ import (
 	v12 "metacontroller/pkg/controller/common/api/v1"
 	v1 "metacontroller/pkg/controller/composite/api/v1"
 	"metacontroller/pkg/logging"
-	"reflect"
 	"strings"
 	"sync"
 
@@ -131,7 +130,7 @@ func (pc *parentController) syncRevisions(parent *unstructured.Unstructured, obs
 		if err := json.Unmarshal(revision.ParentPatch.Raw, &patch); err != nil {
 			return nil, fmt.Errorf("can't unmarshal ControllerRevision parentPatch: %w", err)
 		}
-		if reflect.DeepEqual(patch, latestPatch) {
+		if common.DeepEqual(patch, latestPatch) {
 			// This ControllerRevision matches the latest parent state.
 			latest.revision = revision.DeepCopy()
 			continue
@@ -284,7 +283,7 @@ func (pc *parentController) manageRevisions(parent *unstructured.Unstructured, o
 	for _, revision := range desiredRevisions {
 		if oldObj := observedMap[revision.Name]; oldObj != nil {
 			// Update
-			if reflect.DeepEqual(oldObj, revision) {
+			if common.DeepEqual(oldObj, revision) {
 				// We didn't change anything.
 				continue
 			}

--- a/pkg/controller/composite/rolling_update.go
+++ b/pkg/controller/composite/rolling_update.go
@@ -18,10 +18,8 @@ package composite
 
 import (
 	"fmt"
-	v1 "metacontroller/pkg/controller/common/api/v1"
-	"reflect"
-
 	"metacontroller/pkg/controller/common"
+	v1 "metacontroller/pkg/controller/common/api/v1"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -73,7 +71,7 @@ func (pc *parentController) syncRollingUpdate(parentRevisions []*parentRevision,
 				// We can't prove it'll be a no-op, so don't move it to latest.
 				continue
 			}
-			if reflect.DeepEqual(child, updated) {
+			if common.DeepEqual(child, updated) {
 				// This will be a no-op update, so move it immediately instead of
 				// waiting until the next sync. In addition to reducing unnecessary
 				// ControllerRevision updates, this helps ensure that the overall sync
@@ -185,7 +183,7 @@ func (pc *parentController) shouldContinueRolling(latest *parentRevision, observ
 			if err != nil {
 				return fmt.Errorf("can't check if child %v %v is updated: %w", ck.Kind, name, err)
 			}
-			if !reflect.DeepEqual(child, updated) {
+			if !common.DeepEqual(child, updated) {
 				return fmt.Errorf("child %v %v is not updated yet", ck.Kind, name)
 			}
 			// For RollingInPlace, we should check ObservedGeneration (if possible)

--- a/pkg/controller/decorator/controller.go
+++ b/pkg/controller/decorator/controller.go
@@ -22,7 +22,6 @@ import (
 	commonv1 "metacontroller/pkg/controller/common/api/v1"
 	v1 "metacontroller/pkg/controller/decorator/api/v1"
 	"metacontroller/pkg/hooks"
-	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -580,7 +579,7 @@ func (c *decoratorController) syncParentObject(parent *unstructured.Unstructured
 
 	labelsChanged := updateStringMap(parentLabels, syncResult.Labels)
 	annotationsChanged := updateStringMap(parentAnnotations, syncResult.Annotations)
-	statusChanged := !reflect.DeepEqual(parentStatus, syncResult.Status)
+	statusChanged := !common.DeepEqual(parentStatus, syncResult.Status)
 
 	// Only do the update if something changed.
 	if labelsChanged || annotationsChanged || statusChanged ||


### PR DESCRIPTION
To allow change `reflect.DeepEqual` to semantic equality