### PR TITLE
fix(helm): Use metacontroller.fullname for container name

### DIFF
--- a/deploy/helm/metacontroller/templates/statefulset.yaml
+++ b/deploy/helm/metacontroller/templates/statefulset.yaml
@@ -28,7 +28,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{ include "metacontroller.fullname" . }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"


### PR DESCRIPTION
Small fix to keep name consistent in helm chart.

For example, if you override helm chart name, before this fix it would remain : "metacontroller-helm".
Now, it will mirror the same override helm chart value.