### PR TITLE
cicd(helm): Use dev image for chart testing

### DIFF
--- a/.github/workflows/test_release.yaml
+++ b/.github/workflows/test_release.yaml
@@ -93,12 +93,12 @@ jobs:
         cluster_name: kind
         wait: 120s
 
-    - name: Download metacontroller image
+    - name: Download metacontroller images
       uses: actions/download-artifact@v3
       with:
         name: metacontroller-image
 
-    - name: Load metacontroller image
+    - name: Load metacontroller images
       run: |
         docker load --input metacontroller-dev.tar
         kind load docker-image metacontrollerio/metacontroller:dev
@@ -150,15 +150,21 @@ jobs:
           cluster_name: kind
           wait: 120s
 
-      - name: Download metacontroller debug image
+      - name: Download metacontroller images
         uses: actions/download-artifact@v3
         with:
           name: metacontroller-image
 
-      - name: Load metacontroller debug image
+      - name: Load metacontroller images
         run: |
+          docker load --input metacontroller-dev.tar
+          kind load docker-image metacontrollerio/metacontroller:dev
           docker load --input metacontroller-debug.tar
           kind load docker-image metacontrollerio/metacontroller:debug
+
+      - name: Copy default values.yaml to ci directory with dev image
+        run : |
+          sed 's/tag: ""/tag: "dev"/g' deploy/helm/metacontroller/values.yaml > deploy/helm/metacontroller/ci/default-values.yaml
 
       - name: Run chart-testing (lint-and-install)
         run: |

--- a/deploy/helm/metacontroller/ci/command-args-values.yaml
+++ b/deploy/helm/metacontroller/ci/command-args-values.yaml
@@ -4,7 +4,7 @@ rbac:
 image:
   repository: metacontrollerio/metacontroller
   pullPolicy: IfNotPresent
-  tag: ""
+  tag: "dev"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/deploy/helm/metacontroller/ci/default-values.yaml
+++ b/deploy/helm/metacontroller/ci/default-values.yaml
@@ -1,1 +1,0 @@
-../values.yaml

--- a/deploy/helm/metacontroller/ci/leader-election-values.yaml
+++ b/deploy/helm/metacontroller/ci/leader-election-values.yaml
@@ -4,7 +4,7 @@ rbac:
 image:
   repository: metacontrollerio/metacontroller
   pullPolicy: IfNotPresent
-  tag: ""
+  tag: "dev"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/deploy/helm/metacontroller/ci/rbac-aggregation-rule-values.yaml
+++ b/deploy/helm/metacontroller/ci/rbac-aggregation-rule-values.yaml
@@ -4,7 +4,7 @@ rbac:
 image:
   repository: metacontrollerio/metacontroller
   pullPolicy: IfNotPresent
-  tag: ""
+  tag: "dev"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/deploy/helm/metacontroller/ci/rbac-rules-values.yaml
+++ b/deploy/helm/metacontroller/ci/rbac-rules-values.yaml
@@ -4,7 +4,7 @@ rbac:
 image:
   repository: metacontrollerio/metacontroller
   pullPolicy: IfNotPresent
-  tag: ""
+  tag: "dev"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/deploy/helm/metacontroller/ci/security-context-values.yaml
+++ b/deploy/helm/metacontroller/ci/security-context-values.yaml
@@ -4,7 +4,7 @@ rbac:
 image:
   repository: metacontrollerio/metacontroller
   pullPolicy: IfNotPresent
-  tag: ""
+  tag: "dev"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/deploy/helm/metacontroller/ci/service-values.yaml
+++ b/deploy/helm/metacontroller/ci/service-values.yaml
@@ -4,7 +4,7 @@ rbac:
 image:
   repository: metacontrollerio/metacontroller
   pullPolicy: IfNotPresent
-  tag: ""
+  tag: "dev"
 
 imagePullSecrets: []
 nameOverride: "metacontroller"


### PR DESCRIPTION
Use dev image for helm tests to ensure latest code changes are compatible with chart.

I removed the symbolic link of `ci/default-values.yaml` to `values.yaml` to allow selecting the dev tag. Instead of a symbolic link, sed is used in the github action to replace the tag before executing helm chart testing workflow step.