### PR TITLE
Fix cicd issues

### DIFF
--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -14,7 +14,7 @@ jobs:
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: latest
-          args: --timeout 10m --enable errorlint,gofmt,goimports,gosec,whitespace,bodyclose,dogsled,durationcheck,errorlint,exhaustive,exportloopref,goconst,gocritic,gosec,ifshort,importas,misspell,nilerr --exclude=G108
+          args: --timeout 10m --enable errorlint,gofmt,goimports,gosec,whitespace,bodyclose,dogsled,durationcheck,errorlint,exhaustive,exportloopref,goconst,gocritic,gosec,ifshort,importas,misspell,nilerr --exclude=G108,G122
   docker-linters:
     runs-on: ubuntu-20.04
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /go/src/metacontroller/
 ENV CGO_ENABLED=0
 RUN make install
 
-FROM alpine:3.16.0@sha256:686d8c9dfa6f3ccfc8230bc3178d23f84eeaf7e457f36f271ab1acc53015037c
+FROM alpine:3.16.1@sha256:9b2a28eb47540823042a2ba401386845089bb7b62a9637d55816132c4c3c36eb
 COPY --from=build /go/bin/metacontroller /usr/bin/metacontroller
 RUN apk update && apk add --no-cache ca-certificates
 


### PR DESCRIPTION
Fixes issue with failing CICD checks on linter:
```
Running [/home/runner/golangci-lint-1.47.1-linux-amd64/golangci-lint run --out-format=github-actions --timeout 10m --enable errorlint,gofmt,goimports,gosec,whitespace,bodyclose,dogsled,durationcheck,errorlint,exhaustive,exportloopref,goconst,gocritic,gosec,ifshort,importas,misspell,nilerr --exclude=G108] in [] ...
  Error: G112: Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server (gosec)
  
  level=warning msg="[linters context] bodyclose is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/[26](https://github.com/metacontroller/metacontroller/runs/7416734530?check_suite_focus=true#step:4:28)49."
  level=warning msg="[linters context] nilerr is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649."
  level=warning msg="[linters context] structcheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649."
  
  Error: issues found
  Ran golangci-lint in 101397ms
```

And docker image linter:
```
╔══════════════════════╤═════════════════╤═════════════════╤════════════════════════════════════════════════════╤══════════════════════╗
║ VULNERABILITY ID     │ PACKAGE NAME    │ SEVERITY        │ DESCRIPTION                                        │ TARGET               ║
╟──────────────────────┼─────────────────┼─────────────────┼────────────────────────────────────────────────────┼──────────────────────╢
║ CVE-20[22](https://github.com/metacontroller/metacontroller/runs/7416734254?check_suite_focus=true#step:4:23)-30065       │ busybox         │ HIGH            │ A use-after-free in Busybox 1.35-x's awk applet    │ localhost/           ║
║                      │                 │                 │ leads to denial of service and possibly code       │ metacontroller:lint- ║
║                      │                 │                 │ execution when processing a crafted awk pattern in │ b981d9fb85e8a81cfd0e ║
║                      │                 │                 │ the copyvar function.                              │ 01d3d61c3a86b8a7a89d ║
║                      │                 │                 │                                                    │ (alpine 3.16.0)      ║
╟──────────────────────┼─────────────────┼─────────────────┼────────────────────────────────────────────────────┼──────────────────────╢
║ CVE-2022-2097        │ libcrypto1.1    │ HIGH            │ AES OCB mode for 32-bit x86 platforms using the    │ localhost/           ║
║                      │                 │                 │ AES-NI assembly optimised implementation will not  │ metacontroller:lint- ║
║                      │                 │                 │ encrypt the entirety of the data under some        │ b981d9fb85e8a81cfd0e ║
║                      │                 │                 │ circumstances. This could reveal sixteen bytes of  │ 01d3d61c3a86b8a7a89d ║
║                      │                 │                 │ data that was preexisting in the memory that       │ (alpine 3.16.0)      ║
║                      │                 │                 │ wasn't written. In the special case of "in place"  │                      ║
║                      │                 │                 │ encryption, sixteen bytes of the plaintext would   │                      ║
║                      │                 │                 │ be revealed. Since OpenSSL does not support OCB    │                      ║
║                      │                 │                 │ based cipher suites for TLS and DTLS, they are     │                      ║
║                      │                 │                 │ both unaffected. Fixed in OpenSSL 3.0.5 (Affected  │                      ║
║                      │                 │                 │ 3.0.0-3.0.4). Fixed in OpenSSL 1.1.1q (Affected    │                      ║
║                      │                 │                 │ 1.1.1-1.1.1p).                                     │                      ║
╟──────────────────────┼─────────────────┼─────────────────┼────────────────────────────────────────────────────┼──────────────────────╢
║ CVE-2022-2097        │ libssl1.1       │ HIGH            │ AES OCB mode for 32-bit x86 platforms using the    │ localhost/           ║
║                      │                 │                 │ AES-NI assembly optimised implementation will not  │ metacontroller:lint- ║
║                      │                 │                 │ encrypt the entirety of the data under some        │ b981d9fb85e8a81cfd0e ║
║                      │                 │                 │ circumstances. This could reveal sixteen bytes of  │ 01d3d61c3a86b8a7a89d ║
║                      │                 │                 │ data that was preexisting in the memory that       │ (alpine 3.16.0)      ║
║                      │                 │                 │ wasn't written. In the special case of "in place"  │                      ║
║                      │                 │                 │ encryption, sixteen bytes of the plaintext would   │                      ║
║                      │                 │                 │ be revealed. Since OpenSSL does not support OCB    │                      ║
║                      │                 │                 │ based cipher suites for TLS and DTLS, they are     │                      ║
║                      │                 │                 │ both unaffected. Fixed in OpenSSL 3.0.5 (Affected  │                      ║
║                      │                 │                 │ 3.0.0-3.0.4). Fixed in OpenSSL 1.1.1q (Affected    │                      ║
║                      │                 │                 │ 1.1.1-1.1.1p).                                     │                      ║
╟──────────────────────┼─────────────────┼─────────────────┼────────────────────────────────────────────────────┼──────────────────────╢
║ CVE-2022-30065       │ ssl_client      │ HIGH            │ A use-after-free in Busybox 1.35-x's awk applet    │ localhost/           ║
║                      │                 │                 │ leads to denial of service and possibly code       │ metacontroller:lint- ║
║                      │                 │                 │ execution when processing a crafted awk pattern in │ b981d9fb85e8a81cfd0e ║
║                      │                 │                 │ the copyvar function.                              │ 01d3d61c3a86b8a7a89d ║
║                      │                 │                 │                                                    │ (alpine 3.16.0)      ║
╚══════════════════════╧═════════════════╧═════════════════╧════════════════════════════════════════════════════╧══════════════════════╝
```