### PR TITLE
feat(webhooks): Select json deserialization mode of response: 'loose` (default) or 'strict'

### DIFF
--- a/manifests/production/metacontroller-crds-v1.yaml
+++ b/manifests/production/metacontroller-crds-v1.yaml
@@ -46,6 +46,12 @@ spec:
                     updateStrategy:
                       properties:
                         method:
+                          enum:
+                          - OnDelete
+                          - Recreate
+                          - InPlace
+                          - RollingRecreate
+                          - RollingInPlace
                           type: string
                         statusChecks:
                           properties:
@@ -90,6 +96,14 @@ spec:
                             type: object
                           path:
                             type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
+                            type: string
                           service:
                             properties:
                               name:
@@ -106,6 +120,7 @@ spec:
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -128,6 +143,14 @@ spec:
                             type: object
                           path:
                             type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
+                            type: string
                           service:
                             properties:
                               name:
@@ -144,6 +167,7 @@ spec:
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -166,6 +190,14 @@ spec:
                             type: object
                           path:
                             type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
+                            type: string
                           service:
                             properties:
                               name:
@@ -182,6 +214,7 @@ spec:
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -204,6 +237,14 @@ spec:
                             type: object
                           path:
                             type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
+                            type: string
                           service:
                             properties:
                               name:
@@ -220,6 +261,7 @@ spec:
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -242,6 +284,14 @@ spec:
                             type: object
                           path:
                             type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
+                            type: string
                           service:
                             properties:
                               name:
@@ -258,6 +308,7 @@ spec:
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -405,6 +456,12 @@ spec:
                     updateStrategy:
                       properties:
                         method:
+                          enum:
+                          - OnDelete
+                          - Recreate
+                          - InPlace
+                          - RollingRecreate
+                          - RollingInPlace
                           type: string
                       type: object
                   required:
@@ -431,6 +488,14 @@ spec:
                             type: object
                           path:
                             type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
+                            type: string
                           service:
                             properties:
                               name:
@@ -447,6 +512,7 @@ spec:
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -469,6 +535,14 @@ spec:
                             type: object
                           path:
                             type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
+                            type: string
                           service:
                             properties:
                               name:
@@ -485,6 +559,7 @@ spec:
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -507,6 +582,14 @@ spec:
                             type: object
                           path:
                             type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
+                            type: string
                           service:
                             properties:
                               name:
@@ -523,6 +606,7 @@ spec:
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string

--- a/pkg/apis/metacontroller/v1alpha1/types.go
+++ b/pkg/apis/metacontroller/v1alpha1/types.go
@@ -65,6 +65,7 @@ type CompositeControllerRevisionHistory struct {
 	FieldPaths []string `json:"fieldPaths,omitempty"`
 }
 
+// +kubebuilder:validation:Enum={"OnDelete","Recreate","InPlace","RollingRecreate","RollingInPlace"}
 type ChildUpdateMethod string
 
 const (
@@ -122,13 +123,25 @@ type WebhookEtagConfig struct {
 }
 
 type Webhook struct {
-	URL     *string          `json:"url,omitempty"`
+	URL *string `json:"url,omitempty"`
+	// +kubebuilder:validation:Format:="duration"
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 
 	Etag    *WebhookEtagConfig `json:"etag,omitempty"`
 	Path    *string            `json:"path,omitempty"`
 	Service *ServiceReference  `json:"service,omitempty"`
+	// Sets the json unmarshall mode. One of the 'loose' or 'strict'. In 'strict'
+	// mode additional checks are performed to detect unknown and duplicated fields.
+	ResponseUnmarshallMode *ResponseUnmarshallMode `json:"responseUnMarshallMode,omitempty"`
 }
+
+// +kubebuilder:validation:Enum:={"loose","strict"}
+type ResponseUnmarshallMode string
+
+const (
+	ResponseUnmarshallModeLoose  ResponseUnmarshallMode = "loose"
+	ResponseUnmarshallModeStrict ResponseUnmarshallMode = "strict"
+)
 
 type CompositeControllerStatus struct{}
 

--- a/pkg/apis/metacontroller/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/metacontroller/v1alpha1/zz_generated.deepcopy.go
@@ -762,6 +762,11 @@ func (in *Webhook) DeepCopyInto(out *Webhook) {
 		*out = new(ServiceReference)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ResponseUnmarshallMode != nil {
+		in, out := &in.ResponseUnmarshallMode, &out.ResponseUnmarshallMode
+		*out = new(ResponseUnmarshallMode)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/hooks/webhook_test.go
+++ b/pkg/hooks/webhook_test.go
@@ -1,10 +1,18 @@
 package hooks
 
 import (
+	"bytes"
+	"io"
 	"metacontroller/pkg/controller/common"
+	v1 "metacontroller/pkg/controller/common/customize/api/v1"
+	"metacontroller/pkg/logging"
+	"net/http"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
+	"github.com/go-logr/logr/testr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 
@@ -14,13 +22,9 @@ import (
 func TestNewHookExecutor_whenNilWebHook_returnNilWebhookExecutor(t *testing.T) {
 	executor, err := NewWebhookExecutor(nil, "", common.CompositeController, "")
 
-	if err != nil {
-		t.Errorf("err should be nil, got: %v", err)
-	}
+	assert.NoError(t, err)
 
-	if executor != nil {
-		t.Errorf("WebhookExecutor should be nil")
-	}
+	assert.Nil(t, executor)
 }
 
 func TestWebhookTimeout_defaultTimeoutIfNotSpecified(t *testing.T) {
@@ -41,9 +45,7 @@ func TestWebhookTimeout_defaultTimeoutIfNotSpecified(t *testing.T) {
 
 	for _, table := range tables {
 		duration, _ := webhookTimeout(&table.webhook)
-		if duration != table.duration {
-			t.Errorf("Duration was incorrect, got: %d, want: %d.", duration, table.duration)
-		}
+		assert.Equal(t, table.duration, duration, "Duration was incorrect")
 	}
 }
 func TestWebhookTimeout_defaultTimeoutIfNegative(t *testing.T) {
@@ -64,9 +66,7 @@ func TestWebhookTimeout_defaultTimeoutIfNegative(t *testing.T) {
 
 	for _, table := range tables {
 		duration, _ := webhookTimeout(&table.webhook)
-		if duration != table.duration {
-			t.Errorf("Duration was incorrect, got: %d, want: %d.", duration, table.duration)
-		}
+		assert.Equal(t, table.duration, duration, "Duration was incorrect")
 	}
 }
 
@@ -88,8 +88,57 @@ func TestWebhookTimeout_givenTimeoutIfPositive(t *testing.T) {
 
 	for _, table := range tables {
 		duration, _ := webhookTimeout(&table.webhook)
-		if duration != table.duration {
-			t.Errorf("Duration was incorrect, got: %d, want: %d.", duration, table.duration)
-		}
+		assert.Equal(t, table.duration, duration, "Duration was incorrect")
 	}
+}
+
+type clientMock struct {
+	jsonResponse string
+}
+
+func NewHttpClientMockWithResponse(jsonResponse string) *clientMock {
+	return &clientMock{
+		jsonResponse: jsonResponse,
+	}
+}
+
+func (c *clientMock) Do(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewBufferString(c.jsonResponse)),
+	}, nil
+}
+
+func Test_when_incorrectJsonResponseInLooseMode_deserializeToEmptyResponse(t *testing.T) {
+	logging.Logger = testr.New(t)
+	webhookExecutor := newWebhookExecutor(
+		NewHttpClientMockWithResponse(`{"some": "sother"}`),
+		"",
+		common.CustomizeHook,
+		nil,
+		&webhookExecutorPlain{},
+	)
+
+	var response v1.CustomizeHookResponse
+	err := webhookExecutor.Call(nil, &response)
+	assert.NoError(t, err)
+}
+
+func Test_when_incorrectJsonResponseInStrictMode_thrownError(t *testing.T) {
+	logging.Logger = testr.New(t)
+	webhookExecutor := newWebhookExecutor(
+		NewHttpClientMockWithResponse(`{"some": "sother"}`),
+		"",
+		common.CustomizeHook,
+		toPointer(v1alpha1.ResponseUnmarshallModeStrict),
+		&webhookExecutorPlain{},
+	)
+
+	var response v1.CustomizeHookResponse
+	err := webhookExecutor.Call(nil, &response)
+	assert.Error(t, err)
+}
+
+func toPointer(mode v1alpha1.ResponseUnmarshallMode) *v1alpha1.ResponseUnmarshallMode {
+	return &mode
 }

--- a/pkg/internal/testutils/hooks/hooks.go
+++ b/pkg/internal/testutils/hooks/hooks.go
@@ -26,7 +26,7 @@ import (
 )
 
 // NewHookExecutorStub creates new HookExecutorStub which returns given response
-func NewHookExecutorStub(response interface{}) hooks.Hook {
+func NewHookExecutorStub(response interface{}) *hookExecutorStub {
 	return &hookExecutorStub{
 		enabled:  true,
 		response: response,


### PR DESCRIPTION
Adding possibility to set json deserialize mode to strict, which additionaly check for duplicated and unknown fields. Change is backward-compatibile, it defaults to 'loose'.

In addition, added few validations to CRD's, and used `testify` library.

Fixes #572

Signed-off-by: Grzegorz Głąb <grzesuav@gmail.com>

