### PR TITLE
fix: [#650] - Added 'mountPath' as possible merge-key to avoid that 'name' is treated as unique value for volumeMounts

### DIFF
--- a/pkg/dynamic/apply/apply.go
+++ b/pkg/dynamic/apply/apply.go
@@ -209,6 +209,8 @@ func stringMergeKey(val interface{}) string {
 var knownMergeKeys = []string{
 	"containerPort",
 	"port",
+	"name",
+	"mountPath",
 	"uid",
 	"ip",
 	"path",

--- a/pkg/dynamic/apply/apply.go
+++ b/pkg/dynamic/apply/apply.go
@@ -209,7 +209,6 @@ func stringMergeKey(val interface{}) string {
 var knownMergeKeys = []string{
 	"containerPort",
 	"port",
-	"name",
 	"uid",
 	"ip",
 	"path",

--- a/pkg/dynamic/apply/apply.go
+++ b/pkg/dynamic/apply/apply.go
@@ -209,8 +209,8 @@ func stringMergeKey(val interface{}) string {
 var knownMergeKeys = []string{
 	"containerPort",
 	"port",
-	"name",
 	"mountPath",
+	"name",
 	"uid",
 	"ip",
 	"path",


### PR DESCRIPTION
In issue #650 we ran into the problem that volumeMounts were not correctly merged. This happens when you have multiple volumeMounts that all refer to the same volume, but using different mountPaths. The reason for this seems to come from the merging-algorithm in the meta-controller, which is a bit fuzzy and incorrectly assumes that 'name' always has a unique value (which is not the case here, because 'name' refers to the volume and the same volume can be used for multiple volumeMounts).

In this pull-request we added an "mountPath" option as extra option to the list of possible mergeKeys. This fixes the issue for us, and I think it is reasonably safe to assume that the mountPath property is normally unique.