### PR TITLE
feat(composite controller): Add label selector to choose parent objects

### DIFF
--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -15,7 +15,7 @@ jobs:
       with:
         # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
         version: latest
-        args: --timeout 10m --enable errorlint,gofmt,goimports,gosec,whitespace,bodyclose,dogsled,durationcheck,errorlint,exhaustive,exportloopref,goconst,gocritic,gosec,ifshort,importas,misspell,nilerr --exclude=G108
+        args: --timeout 10m --enable errorlint,gofmt,goimports,gosec,whitespace,bodyclose,dogsled,durationcheck,errorlint,exhaustive,exportloopref,goconst,gocritic,gosec,importas,misspell,nilerr --exclude=G108
   docker-image-for-linting:
     runs-on: ubuntu-22.04
     steps:

--- a/docs/src/api/compositecontroller.md
+++ b/docs/src/api/compositecontroller.md
@@ -82,11 +82,12 @@ better suited for adding behavior to existing resources.
 
 The `parentResource` rule has the following fields:
 
-| Field | Description |
-| ----- | ----------- |
-| `apiVersion` | The API `<group>/<version>` of the parent resource, or just `<version>` for core APIs. (e.g. `v1`, `apps/v1`, `batch/v1`) |
-| `resource`   | The canonical, lowercase, plural name of the parent resource. (e.g. `deployments`, `replicasets`, `statefulsets`) |
-| [`revisionHistory`](#revision-history) | If any [child resources][] use rolling updates, this field specifies how parent revisions are tracked. |
+| Field                                  | Description                                                                                                               |
+|----------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
+| `apiVersion`                           | The API `<group>/<version>` of the parent resource, or just `<version>` for core APIs. (e.g. `v1`, `apps/v1`, `batch/v1`) |
+| `resource`                             | The canonical, lowercase, plural name of the parent resource. (e.g. `deployments`, `replicasets`, `statefulsets`)         |
+| `labelSelector`                        | An optional label selector for narrowing down the objects to target. When not set defaults to all objects                 |
+| [`revisionHistory`](#revision-history) | If any [child resources][] use rolling updates, this field specifies how parent revisions are tracked.                    |
 
 ### Label Selector
 

--- a/examples/bluegreen/test.sh
+++ b/examples/bluegreen/test.sh
@@ -11,7 +11,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-set -ex
+set -eo
 
 bgd="bluegreendeployments"
 

--- a/examples/catset/test.sh
+++ b/examples/catset/test.sh
@@ -12,7 +12,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-set -ex
+set -euo
 
 cs="catsets"
 finalizer="metacontroller.io/catset-test"

--- a/examples/clusteredparent/test.sh
+++ b/examples/clusteredparent/test.sh
@@ -8,7 +8,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-set -ex
+set -euo
 
 echo "Install controller..."
 kubectl apply -k manifest

--- a/examples/configmappropagation/README.md
+++ b/examples/configmappropagation/README.md
@@ -1,6 +1,20 @@
 ## ConfigMap propagation
 
-This is an example CompositeController that propagates a speficied configmap to given namespaces. It uses `customize` hook to select ConfigMap for propagation. Please note that we ignore `labelSelector` setting it to empty one, to select related resources just by namespace/name.
+This is an example CompositeController that propagates a specified configmap to given namespaces. 
+It uses `customize` hook to select ConfigMap for propagation. 
+Please note that we ignore `labelSelector` setting it to empty one, to select related resources just by namespace/name.
+
+Also, in `CompositeControler` we set `labelSelector`
+```yaml
+  parentResource:
+    apiVersion: examples.metacontroller.io/v1alpha1
+    resource: configmappropagations
+    labelSelector:
+      matchLabels:
+        version: v1
+```
+
+to process only one of the `ConfigMapPropagation` CR's.
 
 ### Prerequisites
 

--- a/examples/configmappropagation/example-configmap.yaml
+++ b/examples/configmappropagation/example-configmap.yaml
@@ -32,6 +32,8 @@ apiVersion: examples.metacontroller.io/v1alpha1
 kind: ConfigMapPropagation
 metadata:
   name: settings-propagation
+  labels:
+    version: v1
 spec:
   sourceName: settings
   sourceNamespace: original
@@ -39,4 +41,27 @@ spec:
   - one
   - two
   - three
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: four
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: five
+---
+apiVersion: examples.metacontroller.io/v1alpha1
+kind: ConfigMapPropagation
+metadata:
+  name: settings-propagation-unmanaged
+  labels:
+    version: v2
+spec:
+  sourceName: settings
+  sourceNamespace: original
+  targetNamespaces:
+    - four
+    - five
 

--- a/examples/configmappropagation/manifest/configmap-propagation.yaml
+++ b/examples/configmappropagation/manifest/configmap-propagation.yaml
@@ -8,6 +8,9 @@ spec:
   parentResource:
     apiVersion: examples.metacontroller.io/v1alpha1
     resource: configmappropagations
+    labelSelector:
+      matchLabels:
+        version: v1
   childResources:
   - apiVersion: v1
     resource: configmaps

--- a/examples/configmappropagation/manifest/sync.py
+++ b/examples/configmappropagation/manifest/sync.py
@@ -27,6 +27,8 @@ class Controller(BaseHTTPRequestHandler):
     def sync(self, parent: dict, related: dict) -> dict:
         sourceNamespace: str = parent['spec']['sourceNamespace']
         sourceName: str = parent['spec']['sourceName']
+        parentName = parent['metadata']['name']
+        LOGGER.info(f'Processing: {parentName}')
         if len(related['ConfigMap.v1']) == 0:
             LOGGER.info("Related resource has been deleted, clean-up copies")
             return []

--- a/examples/configmappropagation/test.sh
+++ b/examples/configmappropagation/test.sh
@@ -10,7 +10,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-set -ex
+set -euo
 
 echo "Install controller..."
 kubectl apply -k "${crd_version}"
@@ -24,3 +24,9 @@ until [[ "$(kubectl get cm settings -n two -o 'jsonpath={.metadata.name}')" == "
 until [[ "$(kubectl get cm settings -n three -o 'jsonpath={.metadata.name}')" == "settings" ]]; do sleep 1; done
 echo "Check status update on parent..."
 until [[ "$(kubectl get ConfigMapPropagation settings-propagation -o 'jsonpath={.status.actual_copies}')" == "3" ]]; do sleep 1; done
+sleep 5
+if [[ "$(kubectl get cm settings -n four -o 'jsonpath={.metadata.name}')" == "settings" ]];
+then
+  echo "ERROR: Found configmap in unmanaged namespace"
+  exit 1
+fi

--- a/examples/crd-roles/test.sh
+++ b/examples/crd-roles/test.sh
@@ -10,7 +10,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-set -ex
+set -euo
 
 echo "Install controller..."
 kubectl apply -k "${crd_version}"

--- a/examples/daemonjob/test.sh
+++ b/examples/daemonjob/test.sh
@@ -12,7 +12,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-set -ex
+set -euo
 
 dj="daemonjobs"
 

--- a/examples/globalconfigmap/test.sh
+++ b/examples/globalconfigmap/test.sh
@@ -10,7 +10,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-set -ex
+set -euo
 
 echo "Install controller..."
 kubectl apply -k "${crd_version}"

--- a/examples/indexedjob/test.sh
+++ b/examples/indexedjob/test.sh
@@ -11,7 +11,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-set -ex
+set -euo
 
 ij="indexedjobs"
 

--- a/examples/leader-election/test.sh
+++ b/examples/leader-election/test.sh
@@ -11,7 +11,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-set -ex
+set -euo
 
 success_msg='successfully acquired lease'
 attempt_msg='attempting to acquire leader lease'

--- a/examples/pprof-profiling/test.sh
+++ b/examples/pprof-profiling/test.sh
@@ -11,7 +11,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-set -ex
+set -euo
 
 kubectl apply -f manifest/service.yaml
 sleep 2
@@ -21,7 +21,7 @@ if ((!$?)); then
   echo "Expected failure sending request to disabled pprof"
   exit 1
 fi
-set -ex
+set -euo
 
 echo "Enable pprof on metacontroller..."
 kubectl apply -k ./manifest

--- a/examples/prometheus-monitoring/test.sh
+++ b/examples/prometheus-monitoring/test.sh
@@ -15,7 +15,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-set -ex
+set -euo
 
 echo "Install prometheus..."
 kubectl apply -k github.com/prometheus-operator/prometheus-operator?ref=v0.49.0

--- a/examples/secretpropagation/test.sh
+++ b/examples/secretpropagation/test.sh
@@ -10,7 +10,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-set -ex
+set -euo
 
 echo "Install controller..."
 kubectl apply -k "${crd_version}"

--- a/examples/service-per-pod/test.sh
+++ b/examples/service-per-pod/test.sh
@@ -10,7 +10,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-set -ex
+set -euo
 
 finalizer="metacontroller.io/service-per-pod-test"
 

--- a/manifests/production/metacontroller-crds-v1.yaml
+++ b/manifests/production/metacontroller-crds-v1.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
     "api-approved.kubernetes.io": "unapproved, request not yet submitted"
   name: compositecontrollers.metacontroller.k8s.io
 spec:
@@ -350,6 +350,54 @@ spec:
                 properties:
                   apiVersion:
                     type: string
+                  labelSelector:
+                    description: A label selector is a label query over a set of resources.
+                      The result of matchLabels and matchExpressions are ANDed. An
+                      empty label selector matches all objects. A null label selector
+                      matches no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
                   resource:
                     type: string
                   revisionHistory:
@@ -384,7 +432,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
     "api-approved.kubernetes.io": "unapproved, request not yet submitted"
   name: controllerrevisions.metacontroller.k8s.io
 spec:
@@ -445,7 +493,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
     "api-approved.kubernetes.io": "unapproved, request not yet submitted"
   name: decoratorcontrollers.metacontroller.k8s.io
 spec:

--- a/pkg/apis/metacontroller/v1alpha1/types.go
+++ b/pkg/apis/metacontroller/v1alpha1/types.go
@@ -59,6 +59,7 @@ type ResourceRule struct {
 type CompositeControllerParentResourceRule struct {
 	ResourceRule    `json:",inline"`
 	RevisionHistory *CompositeControllerRevisionHistory `json:"revisionHistory,omitempty"`
+	LabelSelector   *metav1.LabelSelector               `json:"labelSelector,omitempty"`
 }
 
 type CompositeControllerRevisionHistory struct {

--- a/pkg/apis/metacontroller/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/metacontroller/v1alpha1/zz_generated.deepcopy.go
@@ -228,6 +228,11 @@ func (in *CompositeControllerParentResourceRule) DeepCopyInto(out *CompositeCont
 		*out = new(CompositeControllerRevisionHistory)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.LabelSelector != nil {
+		in, out := &in.LabelSelector, &out.LabelSelector
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/controller/composite/hooks_test.go
+++ b/pkg/controller/composite/hooks_test.go
@@ -97,7 +97,8 @@ func TestWhenChildrenArrayIsNullThenDeserializeToEmptySlice(t *testing.T) {
 	"children": [null]
 }`
 	parentController := parentController{
-		syncHook: hooks.NewSerializingExecutorStub(input),
+		syncHook:     hooks.NewSerializingExecutorStub(input),
+		finalizeHook: hooks.NewDisabledExecutorStub(),
 	}
 	parent := &unstructured.Unstructured{}
 	parent.SetDeletionTimestamp(nil)

--- a/pkg/internal/testutils/hooks/hooks.go
+++ b/pkg/internal/testutils/hooks/hooks.go
@@ -33,6 +33,13 @@ func NewHookExecutorStub(response interface{}) *hookExecutorStub {
 	}
 }
 
+func NewDisabledExecutorStub() *hookExecutorStub {
+	return &hookExecutorStub{
+		enabled:  false,
+		response: nil,
+	}
+}
+
 // HookExecutorStub is Hook stub to return any given response
 type hookExecutorStub struct {
 	enabled  bool
@@ -40,7 +47,7 @@ type hookExecutorStub struct {
 }
 
 func (h *hookExecutorStub) IsEnabled() bool {
-	return true
+	return h.enabled
 }
 
 func (h *hookExecutorStub) Call(request hooks.WebhookRequest, response interface{}) error {

--- a/test/integration/framework/metacontroller.go
+++ b/test/integration/framework/metacontroller.go
@@ -61,7 +61,8 @@ func (f *Fixture) CreateCompositeController(name, syncHookURL string, customizeH
 			// Set a big resyncPeriod so tests can precisely control when syncs happen.
 			ResyncPeriodSeconds: pointer.Int32Ptr(3600),
 			ParentResource: v1alpha1.CompositeControllerParentResourceRule{
-				ResourceRule: *parentRule,
+				ResourceRule:  *parentRule,
+				LabelSelector: nil,
 			},
 			ChildResources: childResources,
 			Hooks: &v1alpha1.CompositeControllerHooks{

--- a/test/integration/framework/webhook.go
+++ b/test/integration/framework/webhook.go
@@ -17,7 +17,7 @@ limitations under the License.
 package framework
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 )
@@ -30,7 +30,7 @@ func (f *Fixture) ServeWebhook(handler func(request []byte) (response []byte, er
 			return
 		}
 
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		r.Body.Close()
 		if err != nil {
 			http.Error(w, "can't read body", http.StatusBadRequest)


### PR DESCRIPTION
fixes #695

Adds label selector to composite controller, which works the same way as in decorator controller. I decided not to add annotation selector, as using annotations for selections is against its design.