### PR TITLE
docs(guide): Add openAPIV3Schema to example CRD

### DIFF
--- a/docs/src/guide/create.md
+++ b/docs/src/guide/create.md
@@ -53,6 +53,15 @@ spec:
   - name: v1
     served: true
     storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              who:
+                type: string
     subresources:
      status: {}
 ```


### PR DESCRIPTION
When I tried guide, I can't create a CRD due to validation error.

```shell
The CustomResourceDefinition "helloworlds.example.com" is invalid: spec.versions[0].schema.openAPIV3Schema: Required value: schemas are required
```

So, I added openAPIV3Schema.