### PR TITLE
docs: some clarifications to build and test docs

### DIFF
--- a/docs/src/contrib/build.md
+++ b/docs/src/contrib/build.md
@@ -15,6 +15,20 @@ git clone git@github.com:metacontroller/metacontroller.git metacontroller
 cd metacontroller
 ```
 
+Then you can build a `metacontroller` binary like so:
+
+```sh
+make build
+```
+
+Note that you will need the following k8s code-generation tools:
+* deepcopy-gen
+* client-gen
+* lister-gen
+* informer-gen
+
+...all of which can be found [here](https://github.com/kubernetes/code-generator).
+
 ## Local build and development
 
 Check [debug section](./debug.md)
@@ -74,8 +88,9 @@ and also greatly reduces the requirements to run tests.
 
 Other than the Metacontroller codebase, all you need to run integration tests
 is to download a few binaries from a Kubernetes release.
-You can run the following script to fetch the versions of these binaries
-currently used in continuous integration, and place them in `./hack/bin`:
+You can run the following script from the `test/integration` directory in to
+order to fetch the versions of these binaries currently used in continuous
+integration, and place them in `./hack/bin`:
 
 ```sh
 hack/get-kube-binaries.sh
@@ -103,7 +118,8 @@ that a human might run when using Metacontroller.
 Since these tests verify end-to-end behavior, they require a fully-functioning
 Kubernetes cluster.
 Before running them, you should have `kubectl` in your PATH, and it should be
-configured to talk to a suitable, empty test cluster.
+configured to talk to a suitable, empty test cluster that has had the
+Metacontroller manifests applied.
 
 Then you can run the end-to-end tests against your cluster with the following:
 

--- a/docs/src/contrib/build.md
+++ b/docs/src/contrib/build.md
@@ -21,14 +21,6 @@ Then you can build a `metacontroller` binary like so:
 make build
 ```
 
-Note that you will need the following k8s code-generation tools:
-* deepcopy-gen
-* client-gen
-* lister-gen
-* informer-gen
-
-...all of which can be found [here](https://github.com/kubernetes/code-generator).
-
 ## Local build and development
 
 Check [debug section](./debug.md)

--- a/docs/src/contrib/debug.md
+++ b/docs/src/contrib/debug.md
@@ -12,11 +12,9 @@ There are different flavours of manifests shipped to help with local development
 
 ### Development build
 
-You must first build the binary with `make build`, the following steps will then add it to the Docker image.
-
 The main difference it that image defined in manifest is `metacontrollerio/metacontroller:dev`, therefore:
 * apply dev manifests - `kubectl apply -k manifests/dev`
-* build docker image with command - `docker build -t metacontrollerio/metacontroller:dev -f Dockerfile .`
+* build docker image with command - `make image` - this will compile the binary and build the container image
 * load image into cluster (i.e. `kind load docker-image metacontrollerio/metacontroller:dev` in kind)
 * restart pod
 
@@ -26,7 +24,7 @@ Debug requires building go sources in special way, which is done with `make buil
 built with the `Dockerfile.debug` dockerfile will then add it to the debug Docker image:
 
 * apply debug manifests - `kubectl apply -k manifests/debug`
-* build debug image - `docker build -t metacontrollerio/metacontroller:debug -f Dockerfile.debug .`
+* build debug binary and image - `make image_debug`
 * load image into cluster (i.e. `kind load docker-image metacontrollerio/metacontroller:debug` in kind)
 * restart pod
 * on startup, `go` process will wait for debugger on port 40000

--- a/docs/src/contrib/debug.md
+++ b/docs/src/contrib/debug.md
@@ -12,6 +12,8 @@ There are different flavours of manifests shipped to help with local development
 
 ### Development build
 
+You must first build the binary with `make build`, the following steps will then add it to the Docker image.
+
 The main difference it that image defined in manifest is `metacontrollerio/metacontroller:dev`, therefore:
 * apply dev manifests - `kubectl apply -k manifests/dev`
 * build docker image with command - `docker build -t metacontrollerio/metacontroller:dev -f Dockerfile .`
@@ -20,8 +22,9 @@ The main difference it that image defined in manifest is `metacontrollerio/metac
 
 ### Debug build
 
-Debug requires building go sources in special way, which is done in `Dockerfile.debug` dockerfile.
-In order to use it, please:
+Debug requires building go sources in special way, which is done with `make build_debug`; the following image
+built with the `Dockerfile.debug` dockerfile will then add it to the debug Docker image:
+
 * apply debug manifests - `kubectl apply -k manifests/debug`
 * build debug image - `docker build -t metacontrollerio/metacontroller:debug -f Dockerfile.debug .`
 * load image into cluster (i.e. `kind load docker-image metacontrollerio/metacontroller:debug` in kind)


### PR DESCRIPTION
Signed-off-by: Luke Bond <luke.n.bond@gmail.com>

In the process of making a PR for this project I found some things unclear or missing in the docs. This PR addresses the issues I found.

- It wasn't clear how to compile the binary, therefore I assumed the Docker build would compile it
- Some dependencies were needed for the build that I didn't have installed and took me a while to find
- Path location of the integration test binaries installation script at first appeared wrong but then I found it in a subdir
- The e2e tests don't require an empty cluster, as it states, but one that is already set up with metacontroller