### PR TITLE
chore(docs): correct command for helm install

### DIFF
--- a/docs/src/guide/helm-install.md
+++ b/docs/src/guide/helm-install.md
@@ -13,7 +13,7 @@ helm package deploy/helm/metacontroller --destination deploy/helm
 ## Installing the chart from package
 
 ```shell
-helm install metacontroller deploy/helm/metacontroller-v*.tgz
+helm install metacontroller deploy/helm/metacontroller-helm-v*.tgz
 ```
 
 ## Installing chart from ghcr.io


### PR DESCRIPTION
Seems like the helm package being created is slightly different than what it once may have been:

```
@venkatamutyala ➜ /workspaces/venkatamutyala/metacontroller (master) $ helm package deploy/helm/metacontroller --destination deploy/helm
Successfully packaged chart and saved it to: deploy/helm/metacontroller-helm-v4.7.4.tgz
@venkatamutyala ➜ /workspaces/venkatamutyala/metacontroller (master) $ helm install metacontroller deploy/helm/metacontroller-v*.tgz
Error: INSTALLATION FAILED: repo deploy not found
```

Using the proposed change things work fine:
```
@venkatamutyala ➜ /workspaces/venkatamutyala/metacontroller (master) $ helm install metacontroller deploy/helm/metacontroller-helm-v*.tgz 
NAME: metacontroller
LAST DEPLOYED: Sun Feb  5 19:06:18 2023
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
```