### PR TITLE
fix: Support testing on arm64

### DIFF
--- a/test/integration/hack/setup.sh
+++ b/test/integration/hack/setup.sh
@@ -14,7 +14,16 @@ else
     echo ""
     echo "+++ downloading gotestsum"
     echo ""
+    uname_arch="$(uname -m)"
+    if [[ "${uname_arch}" == "x86_64" ]] ; then
+        gotestsum_arch="amd64"
+    elif [[ "${uname_arch}" == "aarch64" ]] ; then
+        gotestsum_arch="arm64"
+    else
+        >&2 echo "Unknown CPU architecture, cannot install gotestsum"
+        exit 1
+    fi
     mkdir -p "${PWD}"/bin/
-    curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v0.6.0/gotestsum_0.6.0_linux_amd64.tar.gz" | tar -xz -C ${PWD}/bin gotestsum
+    curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v0.6.0/gotestsum_0.6.0_linux_${gotestsum_arch}.tar.gz" | tar -xz -C "${PWD}"/bin gotestsum
     chmod +x "${PWD}"/bin/gotestsum
 fi


### PR DESCRIPTION
gotestsum provides pre-compiled binaries for arm64, but the script was previously hard-coded to only download amd64 binaries. Now it will detect the correct architecture to use before downloading.

I also took this opportunity to surround an instance of `${PWD}` in quotes, so that it's safer and more consistent with the rest of the script.

Signed-off-by: Matthew Gamble <matthew.gamble@rea-group.com>