### PR TITLE
Support rate limiting to handle HTTP 429

### DIFF
--- a/pkg/controller/composite/controller_test.go
+++ b/pkg/controller/composite/controller_test.go
@@ -18,7 +18,6 @@ package composite
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"metacontroller/pkg/apis/metacontroller/v1alpha1"
 	"metacontroller/pkg/client/generated/clientset/internalclientset"
 	mclisters "metacontroller/pkg/client/generated/lister/metacontroller/v1alpha1"
@@ -37,6 +36,8 @@ import (
 	"metacontroller/pkg/logging"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/controller/composite/controller_test.go
+++ b/pkg/controller/composite/controller_test.go
@@ -354,7 +354,7 @@ func Test_parentController_sync_requeue_item_when_hook_throw_TooManyRequestError
 		eventRecorder:  NewFakeRecorder(),
 		finalizer:      DefaultFinalizerManager,
 		customize:      defaultCustomizeManager(),
-		syncHook:       NewErrorExecutorStub(&hooks.TooManyRequestError{0}),
+		syncHook:       NewErrorExecutorStub(&hooks.TooManyRequestError{AfterSecond: 0}),
 		finalizeHook:   NewHookExecutorStub(defaultSyncResponse),
 		logger:         logging.Logger,
 	}

--- a/pkg/hooks/errors.go
+++ b/pkg/hooks/errors.go
@@ -1,6 +1,10 @@
 package hooks
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+	"reflect"
+)
 
 type TooManyRequestError struct {
 	AfterSecond int
@@ -8,4 +12,14 @@ type TooManyRequestError struct {
 
 func (e *TooManyRequestError) Error() string {
 	return fmt.Sprintf("Too many request, it will be resync after: %d", e.AfterSecond)
+}
+
+func UnwrapTo(e error, targetType any) interface{} {
+	for e != nil {
+		if reflect.TypeOf(e).String() == reflect.TypeOf(targetType).String() {
+			return e
+		}
+		e = errors.Unwrap(e)
+	}
+	return nil
 }

--- a/pkg/hooks/errors.go
+++ b/pkg/hooks/errors.go
@@ -1,0 +1,11 @@
+package hooks
+
+import "fmt"
+
+type TooManyRequestError struct {
+	AfterSecond int
+}
+
+func (e *TooManyRequestError) Error() string {
+	return fmt.Sprintf("Too many request, it will be resync after: %d", e.AfterSecond)
+}

--- a/pkg/hooks/errors.go
+++ b/pkg/hooks/errors.go
@@ -1,9 +1,7 @@
 package hooks
 
 import (
-	"errors"
 	"fmt"
-	"reflect"
 )
 
 type TooManyRequestError struct {
@@ -12,14 +10,4 @@ type TooManyRequestError struct {
 
 func (e *TooManyRequestError) Error() string {
 	return fmt.Sprintf("Too many request, it will be resync after: %d", e.AfterSecond)
-}
-
-func UnwrapTo(e error, targetType any) interface{} {
-	for e != nil {
-		if reflect.TypeOf(e).String() == reflect.TypeOf(targetType).String() {
-			return e
-		}
-		e = errors.Unwrap(e)
-	}
-	return nil
 }

--- a/pkg/hooks/webhook.go
+++ b/pkg/hooks/webhook.go
@@ -174,7 +174,7 @@ func (w *webhookExecutor) Call(webhookRequest api.WebhookRequest, webhookRespons
 		} else {
 			afterSecond = int(math.Ceil(nextTime.Sub(w.now()).Seconds()))
 		}
-		return &TooManyRequestError{afterSecond}
+		return &TooManyRequestError{AfterSecond: afterSecond}
 	}
 
 	// Read webhookResponse.

--- a/pkg/hooks/webhook_test.go
+++ b/pkg/hooks/webhook_test.go
@@ -3,7 +3,6 @@ package hooks
 import (
 	"bytes"
 	"fmt"
-	"github.com/pkg/errors"
 	"io"
 	"metacontroller/pkg/controller/common"
 	v1 "metacontroller/pkg/controller/common/customize/api/v1"
@@ -12,6 +11,8 @@ import (
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/stretchr/testify/assert"
 

--- a/pkg/hooks/webhook_test.go
+++ b/pkg/hooks/webhook_test.go
@@ -3,6 +3,7 @@ package hooks
 import (
 	"bytes"
 	"fmt"
+	"github.com/pkg/errors"
 	"io"
 	"metacontroller/pkg/controller/common"
 	v1 "metacontroller/pkg/controller/common/customize/api/v1"
@@ -190,7 +191,9 @@ func Test429Response_thrown_TooManyRequestError(t *testing.T) {
 			)
 
 			err := webhookExecutor.Call(nil, &v1.CustomizeHookResponse{})
-			assert.Equal(t, expectAfterSecond, err.(*TooManyRequestError).AfterSecond)
+			var tooManyRequestError *TooManyRequestError
+			errors.As(err, &tooManyRequestError)
+			assert.Equal(t, expectAfterSecond, tooManyRequestError.AfterSecond)
 		})
 	}
 }

--- a/pkg/internal/testutils/common/util.go
+++ b/pkg/internal/testutils/common/util.go
@@ -17,11 +17,12 @@ limitations under the License.
 package common
 
 import (
+	"metacontroller/pkg/controller/common/finalizer"
+	dynamicdiscovery "metacontroller/pkg/dynamic/discovery"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgotesting "k8s.io/client-go/testing"
-	"metacontroller/pkg/controller/common/finalizer"
-	dynamicdiscovery "metacontroller/pkg/dynamic/discovery"
 
 	"k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/tools/record"

--- a/pkg/internal/testutils/common/util.go
+++ b/pkg/internal/testutils/common/util.go
@@ -17,6 +17,9 @@ limitations under the License.
 package common
 
 import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgotesting "k8s.io/client-go/testing"
 	"metacontroller/pkg/controller/common/finalizer"
 	dynamicdiscovery "metacontroller/pkg/dynamic/discovery"
 
@@ -30,6 +33,18 @@ func NewCh() chan struct{} {
 }
 
 var NoOpFn = func(fakeDynamicClient *fake.FakeDynamicClient) {}
+
+var ListFn = func(fakeDynamicClient *fake.FakeDynamicClient) {
+	fakeDynamicClient.PrependReactor("list", "*", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
+		result := unstructured.UnstructuredList{
+			Object: make(map[string]interface{}),
+			Items: []unstructured.Unstructured{
+				*NewDefaultUnstructured(),
+			},
+		}
+		return true, &result, nil
+	})
+}
 
 var DefaultFinalizerManager = finalizer.NewManager("testFinalizerManager", false)
 

--- a/pkg/internal/testutils/hooks/hooks.go
+++ b/pkg/internal/testutils/hooks/hooks.go
@@ -41,10 +41,15 @@ func NewDisabledExecutorStub() *hookExecutorStub {
 	}
 }
 
+func NewErrorExecutorStub(err error) *hookExecutorStub {
+	return &hookExecutorStub{err: err}
+}
+
 // HookExecutorStub is Hook stub to return any given response
 type hookExecutorStub struct {
 	enabled  bool
 	response interface{}
+	err      error
 }
 
 func (h *hookExecutorStub) IsEnabled() bool {
@@ -52,6 +57,10 @@ func (h *hookExecutorStub) IsEnabled() bool {
 }
 
 func (h *hookExecutorStub) Call(request api.WebhookRequest, response interface{}) error {
+	if h.err != nil {
+		return h.err
+	}
+
 	val := reflect.ValueOf(response)
 	if val.Kind() != reflect.Ptr {
 		return fmt.Errorf(`panic("not a pointer")`)


### PR DESCRIPTION
# Support rate limit

Add a new feature to requeue item when the backend service returns the 429 HTTP code. The requeue after some seconds is based on `Reter-after` field in the response header.
Close: #533 