### PR TITLE
docs: `-a` is not a vaild flag for kubectl get pods

### DIFF
--- a/docs/src/guide/create.md
+++ b/docs/src/guide/create.md
@@ -322,10 +322,8 @@ kubectl -n hello apply -f hello.yaml
 
 Our controller should see this and create a Pod that prints a greeting
 and then exits.
-If you list all Pods (with the `-a` flag) in the `hello` namespace:
-
 ```sh
-kubectl -n hello get pods -a
+kubectl -n hello get pods
 ```
 
 You should see something like this:


### PR DESCRIPTION
kubectl get pods will take -A, which indicates `--all-namespaces` and is not needed in this case because the command declares the namespace