### PR TITLE
refactor: #766 - allowing attachment status change

### DIFF
--- a/docs/src/api/decoratorcontroller.md
+++ b/docs/src/api/decoratorcontroller.md
@@ -126,6 +126,11 @@ Instead, attachments are only connected to the target object
 through owner references, meaning they will get cleaned up
 if the target object is deleted.
 
+Note that, if you are going to put status in the attachment resource thats being
+returned ([more about this in Hooks section](#Hooks)), you need to make sure that 
+there is no race with another controller trying to set the status of concerned 
+attachment. 
+
 Each entry in the `attachments` list has the following fields:
 
 | Field | Description |

--- a/docs/src/api/decoratorcontroller.md
+++ b/docs/src/api/decoratorcontroller.md
@@ -128,8 +128,8 @@ if the target object is deleted.
 
 Note that, if you are going to put status in the attachment resource thats being
 returned ([more about this in Hooks section](#Hooks)), you need to make sure that 
-there is no race with another controller trying to set the status of concerned 
-attachment. 
+there isn't going to be a race condition with another controller which is also 
+trying to set the status of the concerned attachment. 
 
 Each entry in the `attachments` list has the following fields:
 

--- a/pkg/controller/common/manage_children.go
+++ b/pkg/controller/common/manage_children.go
@@ -54,11 +54,6 @@ func ApplyUpdate(orig, update *unstructured.Unstructured) (*unstructured.Unstruc
 	if err := revertObjectMetaSystemFields(newObj, orig); err != nil {
 		return nil, fmt.Errorf("failed to revert ObjectMeta system fields: %w", err)
 	}
-	// Revert status because we don't currently support a parent changing status of
-	// its children, so we need to ensure no diffs on the children involve status.
-	if err := revertField(newObj, orig, "status"); err != nil {
-		return nil, fmt.Errorf("failed to revert .status: %w", err)
-	}
 	if err = dynamicapply.SetLastApplied(newObj, update.UnstructuredContent()); err != nil {
 		logging.Logger.Error(err, "failed to set lastApplied")
 	}


### PR DESCRIPTION
This PR simply allows `status` changes in an `attachment` resource when using `DecoratorController`

More context: https://kubernetes.slack.com/archives/CA0SUPUDP/p1678098438458439?thread_ts=1677578734.006459&cid=CA0SUPUDP

cc @grzesuav 