### PR TITLE
chore(docs): Updated local development image name

### DIFF
--- a/docs/src/contrib/debug.md
+++ b/docs/src/contrib/debug.md
@@ -12,11 +12,11 @@ There are different flavours of manifests shipped to help with local development
 
 ### Development build
 
-The main difference it that image defined in manifest is `metacontrollerio/metacontroller:dev`, therefore:
+The main difference it that image defined in manifest is `localhost/metacontroller:dev`, therefore:
 * apply dev manifests - `kubectl apply -k manifests/dev`
 * build docker image with command - `make image` - this will compile the binary and build the container image
-* load image into cluster (i.e. `kind load docker-image metacontrollerio/metacontroller:dev` in kind)
-* restart pod
+* load image into cluster (i.e. `kind load docker-image localhost/metacontroller:dev` in kind)
+* restart pod (i.e. `kubectl delete pod/metacontroller-0 --namespace metacontroller`)
 
 ### Debug build
 
@@ -25,7 +25,7 @@ built with the `Dockerfile.debug` dockerfile will then add it to the debug Docke
 
 * apply debug manifests - `kubectl apply -k manifests/debug`
 * build debug binary and image - `make image_debug`
-* load image into cluster (i.e. `kind load docker-image metacontrollerio/metacontroller:debug` in kind)
+* load image into cluster (i.e. `kind load docker-image localhost/metacontroller:debug` in kind)
 * restart pod
 * on startup, `go` process will wait for debugger on port 40000
 * port forward port 40000 from container into localhost, i.e. `kubectl port-forward metacontroller-0 40000:40000`


### PR DESCRIPTION
Found the documentation misleading when I tried to setup a local environment. I checked the dev deployment and found that the image name was incorrect on the documentation.

Herewith please find my fix for this. Thank you.