### PR TITLE
fix(hooks): Make ETag header RFC compliant

### DIFF
--- a/docs/src/api/hook.md
+++ b/docs/src/api/hook.md
@@ -43,11 +43,11 @@ Within a `webhook`, the `service` field has the following subfields:
 
 ### Etag Reference
 
-More details in [rfc2616](https://datatracker.ietf.org/doc/html/rfc2616).
+More details in [rfc7232](https://www.rfc-editor.org/rfc/rfc7232).
 
 Etag is a hash of response content, controller that supports etag notion should add "ETag" header to each 200 response.
-Metacontroller that supports "ETag" should send "If-None-Match" tag with value of ETag of cached content.
-If content have not changed controller replies with "304 Not modified", otherwise it sends 200 with "ETag" header.
+Metacontrollers that support "ETag" should send the "If-None-Match" header with value of ETag of cached content.
+If content has not changed, controller should reply with "304 Not modified" or "412 Precondition Failed", otherwise it sends 200 with "ETag" header.
 
 This logic helps save traffic and CPU time on webhook processing.
 

--- a/pkg/hooks/webhook_etag_test.go
+++ b/pkg/hooks/webhook_etag_test.go
@@ -92,6 +92,18 @@ func httpResponse304NotModified() *MockResponse {
 	}
 }
 
+func httpResponse412NotModified() *MockResponse {
+	return &MockResponse{
+		&http.Response{
+			Status:     "412 Precondition Failed",
+			StatusCode: 412,
+			Header:     map[string][]string{},
+			Body:       io.NopCloser(bytes.NewBufferString("")),
+		},
+		nil,
+	}
+}
+
 func httpResponse200(body string, etag string) *MockResponse {
 	t := http.Response{
 		Status:     "200 OK",
@@ -169,6 +181,13 @@ func TestHookETag(t *testing.T) {
 		},
 		{
 			httpResponse: httpResponse304NotModified(),
+			expectedHeaders: map[string]string{
+				"If-None-Match": "000-000-000-001",
+			},
+			hookResult: hookResultFromJson(body1),
+		},
+		{
+			httpResponse: httpResponse412NotModified(),
 			expectedHeaders: map[string]string{
 				"If-None-Match": "000-000-000-001",
 			},


### PR DESCRIPTION
Fixes #850

Adds support for `412 (Precondition Failed)` responses from controllers when the provided `If-None-Match` header contains the `ETag`. As described in #850, this is the expected behavior of HTTP/1.1 as described in [RFC7232](https://www.rfc-editor.org/rfc/rfc7232#section-3.2).

I also took the liberty of updating the docs.