### PR TITLE
fix(related_resources): Call getCustomizeHookResponse instead of getCachedCustomizeHookResponse

### DIFF
--- a/pkg/controller/common/customize/manager.go
+++ b/pkg/controller/common/customize/manager.go
@@ -251,9 +251,9 @@ func (rm *Manager) findRelatedParents(relatedSlice ...*unstructured.Unstructured
 
 	MATCHPARENTS:
 		for _, parent := range parents {
-			customizeHookResponse, found := rm.getCachedCustomizeHookResponse(parent)
-
-			if !found {
+			customizeHookResponse, err := rm.getCustomizeHookResponse(parent)
+			if err != nil || customizeHookResponse == nil {
+				// skip for now, the informer relist interval will try again later.
 				continue
 			}
 


### PR DESCRIPTION
The customize hook cache would reach TTL and expire; the cached item would no longer be found. The loop in find findRelatedParents would trigger the continue which would skip over all the related rules to be processed.

By replacing getCachedCustomizeHookResponse with getCustomizeHookResponse, if the cached item is not found, it would then trigger the customize hook call and update the cache. The related items would then continue to be processed.

fixes: https://github.com/metacontroller/metacontroller/issues/731 