### PR TITLE
fix(helm): [#946] - Drop v prefix from helm chart version

### DIFF
--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -26,4 +26,5 @@ jobs:
           helm package ${{ github.workspace }}/deploy/helm/metacontroller/
       - name: publish chart to ghcr.io
         run: |
-          helm push metacontroller-helm-${{ github.ref_name }}.tgz oci://ghcr.io/metacontroller
+          VERSION="${GITHUB_REF_NAME#v}"
+          helm push metacontroller-helm-${VERSION}.tgz oci://ghcr.io/metacontroller

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -299,5 +299,9 @@ release:
     - `{{ .Env.REPOSITORY_OWNER }}io/{{ .ProjectName }}:v{{ .Version }}`
     - `{{ .Env.REPOSITORY_OWNER }}io/{{ .ProjectName }}:v{{ .Version }}-distroless`
     - `{{ .Env.REPOSITORY_OWNER }}io/{{ .ProjectName }}:v{{ .Version }}-distroless-debug`
+    ## Helm chart
+    ### Github container registry
+    - `ghcr.io/{{ .Env.REPOSITORY_OWNER }}/{{ .ProjectName }}-helm:{{ .Version }}`
+
   extra_files:
     - glob: manifests/production/*

--- a/release.config.js
+++ b/release.config.js
@@ -29,18 +29,32 @@ module.exports = {
           },
           {
             "files": ["deploy/helm/metacontroller/Chart.yaml"],
-            "from": "(version|appVersion): v.*",
-            "to": "$1: v${nextRelease.version}",
+            "from": "appVersion: v.*",
+            "to": "appVersion: v${nextRelease.version}",
             "results": [
               {
                 "file": "deploy/helm/metacontroller/Chart.yaml",
                 "hasChanged": true,
-                "numMatches": 2,
-                "numReplacements": 2
+                "numMatches": 1,
+                "numReplacements": 1
               }
             ],
             "countMatches": true
-          }
+          },
+          {
+            "files": ["deploy/helm/metacontroller/Chart.yaml"],
+            "from": "version: .*",
+            "to": "version: ${nextRelease.version}",
+            "results": [
+              {
+                "file": "deploy/helm/metacontroller/Chart.yaml",
+                "hasChanged": true,
+                "numMatches": 1,
+                "numReplacements": 1
+              }
+            ],
+            "countMatches": true
+          },
         ]
       }
     ],


### PR DESCRIPTION
Helm only respects strict semver v2. That means no v prefixes.

This change removes the v prefix both from the chart and the published
OCI artifact tag.

Fixes #946
