### PR TITLE
feat: #986 - Ignore status changes for parent resources in dec and cc controller

### DIFF
--- a/deploy/helm/metacontroller/crds/metacontroller-crds-v1.yaml
+++ b/deploy/helm/metacontroller/crds/metacontroller-crds-v1.yaml
@@ -350,6 +350,8 @@ spec:
                 properties:
                   apiVersion:
                     type: string
+                  ignoreStatusChanges:
+                    type: boolean
                   labelSelector:
                     description: A label selector is a label query over a set of resources.
                       The result of matchLabels and matchExpressions are ANDed. An
@@ -754,6 +756,8 @@ spec:
                       type: object
                     apiVersion:
                       type: string
+                    ignoreStatusChanges:
+                      type: boolean
                     labelSelector:
                       description: A label selector is a label query over a set of
                         resources. The result of matchLabels and matchExpressions

--- a/docs/src/api/compositecontroller.md
+++ b/docs/src/api/compositecontroller.md
@@ -82,12 +82,13 @@ better suited for adding behavior to existing resources.
 
 The `parentResource` rule has the following fields:
 
-| Field                                  | Description                                                                                                               |
-|----------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
-| `apiVersion`                           | The API `<group>/<version>` of the parent resource, or just `<version>` for core APIs. (e.g. `v1`, `apps/v1`, `batch/v1`) |
-| `resource`                             | The canonical, lowercase, plural name of the parent resource. (e.g. `deployments`, `replicasets`, `statefulsets`)         |
-| `labelSelector`                        | An optional label selector for narrowing down the objects to target. When not set defaults to all objects                 |
-| [`revisionHistory`](#revision-history) | If any [child resources][] use rolling updates, this field specifies how parent revisions are tracked.                    |
+| Field                               | Description                                                                                                                                                                           |
+|-------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `apiVersion`                        | The API `<group>/<version>` of the parent resource, or just `<version>` for core APIs. (e.g. `v1`, `apps/v1`, `batch/v1`)                                                             |
+| `resource`                          | The canonical, lowercase, plural name of the parent resource. (e.g. `deployments`, `replicasets`, `statefulsets`)                                                                     |
+| `labelSelector`                     | An optional label selector for narrowing down the objects to target. When not set defaults to all objects                                                                             |
+| [`revisionHistory`](#revision-history) | If any [child resources][] use rolling updates, this field specifies how parent revisions are tracked.                                                                                |
+| `ignoreStatusChanges`               | An optional field through which status changes can be ignored for reconcilation. If set to `true`, only spec changes or labels/annotations changes will reconcile the parent resource. |
 
 ### Label Selector
 

--- a/docs/src/api/decoratorcontroller.md
+++ b/docs/src/api/decoratorcontroller.md
@@ -60,12 +60,13 @@ call your [sync hook](#sync-hook) to ask for your desired state.
 
 Each entry in the `resources` list has the following fields:
 
-| Field | Description |
-| ----- | ----------- |
-| `apiVersion` | The API `<group>/<version>` of the target resource, or just `<version>` for core APIs. (e.g. `v1`, `apps/v1`, `batch/v1`) |
-| `resource`   | The canonical, lowercase, plural name of the target resource. (e.g. `deployments`, `replicasets`, `statefulsets`) |
-| [`labelSelector`](#label-selector) | An optional label selector for narrowing down the objects to target. |
-| [`annotationSelector`](#annotation-selector) | An optional annotation selector for narrowing down the objects to target. |
+| Field                                        | Description                                                                                                                                                                            |
+|----------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `apiVersion`                                 | The API `<group>/<version>` of the target resource, or just `<version>` for core APIs. (e.g. `v1`, `apps/v1`, `batch/v1`)                                                              |
+| `resource`                                   | The canonical, lowercase, plural name of the target resource. (e.g. `deployments`, `replicasets`, `statefulsets`)                                                                      |
+| [`labelSelector`](#label-selector)           | An optional label selector for narrowing down the objects to target.                                                                                                                   |
+| [`annotationSelector`](#annotation-selector) | An optional annotation selector for narrowing down the objects to target.                                                                                                              |
+| `ignoreStatusChanges`                        | An optional field through which status changes can be ignored for reconcilation. If set to `true`, only spec changes or labels/annotations changes will reconcile the parent resource. |
 
 ### Label Selector
 

--- a/pkg/apis/metacontroller/v1alpha1/types.go
+++ b/pkg/apis/metacontroller/v1alpha1/types.go
@@ -58,9 +58,10 @@ type ResourceRule struct {
 }
 
 type CompositeControllerParentResourceRule struct {
-	ResourceRule    `json:",inline"`
-	RevisionHistory *CompositeControllerRevisionHistory `json:"revisionHistory,omitempty"`
-	LabelSelector   *metav1.LabelSelector               `json:"labelSelector,omitempty"`
+	ResourceRule        `json:",inline"`
+	RevisionHistory     *CompositeControllerRevisionHistory `json:"revisionHistory,omitempty"`
+	LabelSelector       *metav1.LabelSelector               `json:"labelSelector,omitempty"`
+	IgnoreStatusChanges *bool                               `json:"ignoreStatusChanges,omitempty"`
 }
 
 type CompositeControllerRevisionHistory struct {
@@ -224,9 +225,10 @@ type DecoratorControllerSpec struct {
 }
 
 type DecoratorControllerResourceRule struct {
-	ResourceRule       `json:",inline"`
-	LabelSelector      *metav1.LabelSelector `json:"labelSelector,omitempty"`
-	AnnotationSelector *AnnotationSelector   `json:"annotationSelector,omitempty"`
+	ResourceRule        `json:",inline"`
+	LabelSelector       *metav1.LabelSelector `json:"labelSelector,omitempty"`
+	AnnotationSelector  *AnnotationSelector   `json:"annotationSelector,omitempty"`
+	IgnoreStatusChanges *bool                 `json:"ignoreStatusChanges,omitempty"`
 }
 
 type AnnotationSelector struct {

--- a/pkg/apis/metacontroller/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/metacontroller/v1alpha1/zz_generated.deepcopy.go
@@ -233,6 +233,11 @@ func (in *CompositeControllerParentResourceRule) DeepCopyInto(out *CompositeCont
 		*out = new(v1.LabelSelector)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.IgnoreStatusChanges != nil {
+		in, out := &in.IgnoreStatusChanges, &out.IgnoreStatusChanges
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 
@@ -553,6 +558,11 @@ func (in *DecoratorControllerResourceRule) DeepCopyInto(out *DecoratorController
 		in, out := &in.AnnotationSelector, &out.AnnotationSelector
 		*out = new(AnnotationSelector)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.IgnoreStatusChanges != nil {
+		in, out := &in.IgnoreStatusChanges, &out.IgnoreStatusChanges
+		*out = new(bool)
+		**out = **in
 	}
 	return
 }


### PR DESCRIPTION
fixes part of #986

- introduces a field `ignoreStatusChanges` in the API of both - decorator and composite controller
- if its set to `true`, only spec changes or label/annotation changes will be honored for reconcilation.