### PR TITLE
fix: allow update enqueue for parent resources being deleted when ignoreStatusChanges is being set to true

### DIFF
--- a/pkg/controller/composite/controller.go
+++ b/pkg/controller/composite/controller.go
@@ -364,10 +364,12 @@ func (pc *parentController) updateParentObject(old, cur interface{}) {
 		if parentOld, ok := old.(*unstructured.Unstructured); ok {
 			if parentCur, ok := cur.(*unstructured.Unstructured); ok {
 				// if ignoreStatusChanges is set to true in the composite controller, a parent object should only be
-				// enqueued if either there is a change in the generation or if there is a change in its labels/annotations,
-				// otherwise it will be ignored.
+				// enqueued if there is a change in the generation or if there is a change in its labels/annotations,
+				// or if there is a deletion timestamp attached to the object, otherwise it will be ignored.
 				if parentOld.GetGeneration() == parentCur.GetGeneration() {
-					if reflect.DeepEqual(parentOld.GetLabels(), parentCur.GetLabels()) && reflect.DeepEqual(parentOld.GetAnnotations(), parentCur.GetAnnotations()) {
+					if reflect.DeepEqual(parentOld.GetLabels(), parentCur.GetLabels()) &&
+						reflect.DeepEqual(parentOld.GetAnnotations(), parentCur.GetAnnotations()) &&
+						parentCur.GetDeletionTimestamp() == nil {
 						return
 					}
 				}

--- a/pkg/controller/decorator/controller.go
+++ b/pkg/controller/decorator/controller.go
@@ -362,12 +362,14 @@ func (c *decoratorController) updateParentObject(old, cur interface{}) {
 			}
 			if resource.APIVersion == parentAPIVersion && resource.Kind == parentKind {
 				// if ignoreStatusChanges is set to true in the decorator controller, a parent object should only be
-				// enqueued if either there is a change in the generation or if there is a change in its labels/annotations,
-				// otherwise it will be ignored.
+				// enqueued if there is a change in the generation or if there is a change in its labels/annotations,
+				// or if there is a deletion timestamp attached to the object, otherwise it will be ignored.
 				if parent.IgnoreStatusChanges != nil && *parent.IgnoreStatusChanges {
 					if parentCur, ok := cur.(*unstructured.Unstructured); ok {
 						if parentOld.GetGeneration() == parentCur.GetGeneration() {
-							if reflect.DeepEqual(parentOld.GetLabels(), parentCur.GetLabels()) && reflect.DeepEqual(parentOld.GetAnnotations(), parentCur.GetAnnotations()) {
+							if reflect.DeepEqual(parentOld.GetLabels(), parentCur.GetLabels()) &&
+								reflect.DeepEqual(parentOld.GetAnnotations(), parentCur.GetAnnotations()) &&
+								parentCur.GetDeletionTimestamp() == nil {
 								return
 							}
 						}


### PR DESCRIPTION
fixes part of https://github.com/metacontroller/metacontroller/issues/986

we should also handle the case when `deletiontimestamp` is added to the parent object, metacontroller should enqueue it. Otherwise, whenever a parent object is deleted, because only timestamp is added in metadata, it will come to `updateParentObject()` method which will ignore it because there has been no change in the generation, labels or annotations.