### PR TITLE
chore(examples): update python examples to use python 3.11

### DIFF
--- a/examples/bluegreen/my-bluegreen.yaml
+++ b/examples/bluegreen/my-bluegreen.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:1.7.9
+        image: nginx:1.26.2
         ports:
         - containerPort: 80
   service:

--- a/examples/catset/my-catset.yaml
+++ b/examples/catset/my-catset.yaml
@@ -36,7 +36,7 @@ spec:
       terminationGracePeriodSeconds: 1
       containers:
       - name: nginx
-        image: gcr.io/google_containers/nginx-slim:0.8
+        image: nginx:1.26.2
         ports:
         - containerPort: 80
           name: web

--- a/examples/clusteredparent/manifest/cluster-parent.yaml
+++ b/examples/clusteredparent/manifest/cluster-parent.yaml
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
       - name: controller
-        image: python:2.7
+        image: python:3.11
         command: ["python", "/hooks/sync.py"]
         volumeMounts:
         - name: hooks

--- a/examples/clusteredparent/manifest/sync.py
+++ b/examples/clusteredparent/manifest/sync.py
@@ -14,11 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import io
 import json
 
 def new_rolebinding(name):
-  rolebinding = {}
+  rolebinding = dict()
   rolebinding['apiVersion'] = 'rbac.authorization.k8s.io/v1'
   rolebinding['kind'] = 'RoleBinding'
   rolebinding['metadata'] = {}
@@ -28,18 +29,20 @@ def new_rolebinding(name):
   rolebinding['roleRef'] = {'kind': 'ClusterRole', 'name': name, 'apiGroup': 'rbac.authorization.k8s.io'}
   return rolebinding
 
+
 class Controller(BaseHTTPRequestHandler):
   def sync(self, clusterrole, children):
     return {'attachments': [new_rolebinding(clusterrole['metadata']['name'])] }
 
 
   def do_POST(self):
-    observed = json.loads(self.rfile.read(int(self.headers.getheader('content-length'))))
+    observed = json.loads(self.rfile.read(int(self.headers.get('content-length'))))
     desired = self.sync(observed['object'], observed['attachments'])
 
     self.send_response(200)
     self.send_header('Content-type', 'application/json')
     self.end_headers()
-    self.wfile.write(json.dumps(desired))
+    self.wfile.write(io.BytesIO(json.dumps(desired).encode('utf-8')).getvalue())
+
 
 HTTPServer(('', 80), Controller).serve_forever()

--- a/examples/clusteredparent/sync.py
+++ b/examples/clusteredparent/sync.py
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, HTTPServer
 import json
 
 def new_rolebinding(name):
-  rolebinding = {}
+  rolebinding = dict()
   rolebinding['apiVersion'] = 'rbac.authorization.k8s.io/v1'
   rolebinding['kind'] = 'RoleBinding'
   rolebinding['metadata'] = {}
@@ -34,12 +34,12 @@ class Controller(BaseHTTPRequestHandler):
 
 
   def do_POST(self):
-    observed = json.loads(self.rfile.read(int(self.headers.getheader('content-length'))))
+    observed = json.loads(self.rfile.read(int(self.headers.get('content-length'))))
     desired = self.sync(observed['object'], observed['attachments'])
 
     self.send_response(200)
     self.send_header('Content-type', 'application/json')
     self.end_headers()
-    self.wfile.write(json.dumps(desired))
+    self.wfile.write(io.BytesIO(json.dumps(desired).encode('utf-8')).getvalue())
 
 HTTPServer(('', 80), Controller).serve_forever()

--- a/examples/configmappropagation/manifest/configmap-propagation.yaml
+++ b/examples/configmappropagation/manifest/configmap-propagation.yaml
@@ -41,7 +41,7 @@ spec:
     spec:
       containers:
       - name: controller
-        image: python:3.9
+        image: python:3.11
         command: ["python", "/hooks/sync.py"]
         volumeMounts:
         - name: hooks

--- a/examples/configmappropagation/manifest/sync.py
+++ b/examples/configmappropagation/manifest/sync.py
@@ -15,27 +15,27 @@
 # limitations under the License.
 
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import List
 import json
 import logging
-import typing
 
 logging.basicConfig(level=logging.DEBUG)
 LOGGER = logging.getLogger(__name__)
 
 
 class Controller(BaseHTTPRequestHandler):
-    def sync(self, parent: dict, related: dict) -> dict:
-        sourceNamespace: str = parent['spec']['sourceNamespace']
-        sourceName: str = parent['spec']['sourceName']
-        parentName = parent['metadata']['name']
-        LOGGER.info(f'Processing: {parentName}')
+    def sync(self, parent: dict, related: dict) -> List[dict]:
+        source_namespace: str = parent['spec']['sourceNamespace']
+        source_name: str = parent['spec']['sourceName']
+        parent_name = parent['metadata']['name']
+        LOGGER.info(f'Processing: {parent_name}')
         if len(related['ConfigMap.v1']) == 0:
             LOGGER.info("Related resource has been deleted, clean-up copies")
             return []
-        original_configmap: dict = related['ConfigMap.v1'][f'{sourceNamespace}/{sourceName}']
-        targetNamespaces: list[str] = parent['spec']['targetNamespaces']
+        original_configmap: dict = related['ConfigMap.v1'][f'{source_namespace}/{source_name}']
+        target_namespaces: list[str] = parent['spec']['targetNamespaces']
         target_configmaps = [self.new_configmap(
-            sourceName, namespace, original_configmap['data']) for namespace in targetNamespaces]
+            source_name, namespace, original_configmap['data']) for namespace in target_namespaces]
         return target_configmaps
 
     def new_configmap(self, name: str, namespace: str, data: dict) -> dict:
@@ -49,13 +49,13 @@ class Controller(BaseHTTPRequestHandler):
             'data': data
         }
 
-    def customize(self, sourceName: str, sourceNamespace: str) -> dict:
+    def customize(self, source_name: str, source_namespace: str) -> List[dict]:
         return [
             {
                 'apiVersion': 'v1',
                 'resource': 'configmaps',
-                'namespace': sourceNamespace,
-                'names': [sourceName]
+                'namespace': source_namespace,
+                'names': [source_name]
             }
         ]
 

--- a/examples/crd-roles/manifest/crd-role-controller.yaml
+++ b/examples/crd-roles/manifest/crd-role-controller.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: controller
-        image: python:2.7
+        image: python:3.11
         command: ["python", "/hooks/sync.py"]
         volumeMounts:
         - name: hooks

--- a/examples/daemonjob/manifest/daemonjob-controller.yaml
+++ b/examples/daemonjob/manifest/daemonjob-controller.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: controller
-        image: python:2.7
+        image: python:3.11
         command: ["python", "/hooks/sync.py"]
         volumeMounts:
         - name: hooks

--- a/examples/daemonjob/manifest/sync.py
+++ b/examples/daemonjob/manifest/sync.py
@@ -14,7 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import io
 import json
 import copy
 import re
@@ -76,12 +77,13 @@ class Controller(BaseHTTPRequestHandler):
 
 
   def do_POST(self):
-    observed = json.loads(self.rfile.read(int(self.headers.getheader('content-length'))))
+    observed = json.loads(self.rfile.read(int(self.headers.get('content-length'))))
     desired = self.sync(observed['parent'], observed['children'])
 
     self.send_response(200)
     self.send_header('Content-type', 'application/json')
     self.end_headers()
-    self.wfile.write(json.dumps(desired))
+    self.wfile.write(io.BytesIO(json.dumps(desired).encode('utf-8')).getvalue())
+
 
 HTTPServer(('', 80), Controller).serve_forever()

--- a/examples/globalconfigmap/manifest/globalconfigmap.yaml
+++ b/examples/globalconfigmap/manifest/globalconfigmap.yaml
@@ -38,7 +38,7 @@ spec:
     spec:
       containers:
       - name: controller
-        image: python:3.9
+        image: python:3.11
         command: ["python", "/hooks/sync.py"]
         volumeMounts:
         - name: hooks

--- a/examples/globalconfigmap/manifest/sync.py
+++ b/examples/globalconfigmap/manifest/sync.py
@@ -15,28 +15,28 @@
 # limitations under the License.
 
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import List
 import json
 import logging
-import typing
 
 logging.basicConfig(level=logging.DEBUG)
 LOGGER = logging.getLogger(__name__)
 
 
 class Controller(BaseHTTPRequestHandler):
-    def sync(self, parent: dict, related: dict) -> dict:
-        sourceNamespace: str = parent['spec']['sourceNamespace']
-        sourceName: str = parent['spec']['sourceName']
+    def sync(self, parent: dict, related: dict) -> List[dict]:
+        source_namespace: str = parent['spec']['sourceNamespace']
+        source_name: str = parent['spec']['sourceName']
         if len(related['ConfigMap.v1']) == 0:
             LOGGER.info("Related resource has been deleted, clean-up copies")
             return []
-        original_configmap: dict = related['ConfigMap.v1'][f'{sourceNamespace}/{sourceName}']
-        targetNamespaces = related['Namespace.v1']
+        original_configmap: dict = related['ConfigMap.v1'][f'{source_namespace}/{source_name}']
+        target_namespaces = related['Namespace.v1']
         target_configmaps = []
-        for namespace in targetNamespaces.values():
-            if namespace['metadata']['name'] != sourceNamespace:
+        for namespace in target_namespaces.values():
+            if namespace['metadata']['name'] != source_namespace:
                 target_configmaps.append(self.new_configmap(
-                    sourceName, namespace['metadata']['name'], original_configmap['data']))
+                    source_name, namespace['metadata']['name'], original_configmap['data']))
         return target_configmaps
 
     def new_configmap(self, name: str, namespace: str, data: dict) -> dict:
@@ -50,7 +50,7 @@ class Controller(BaseHTTPRequestHandler):
             'data': data
         }
 
-    def customize(self, sourceName: str, sourceNamespace: str) -> dict:
+    def customize(self, sourceName: str, sourceNamespace: str) -> List[dict]:
         return [
             {
                 'apiVersion': 'v1',

--- a/examples/indexedjob/manifest/indexedjob-controller.yaml
+++ b/examples/indexedjob/manifest/indexedjob-controller.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: controller
-        image: python:2.7
+        image: python:3.11
         command: ["python", "/hooks/sync.py"]
         volumeMounts:
         - name: hooks

--- a/examples/kind-load-images.sh
+++ b/examples/kind-load-images.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Load up all the images to kind cluster
+CLUSTER="metacontroller"
+
+docker pull nginx:1.26.2
+docker pull metacontroller/nodejs-server:0.1
+docker pull python:3.11
+docker pull busybox
+docker pull metacontroller/jsonnetd:0.1
+
+kind load docker-image --name ${CLUSTER} nginx:1.26.2
+kind load docker-image --name ${CLUSTER} metacontroller/nodejs-server:0.1
+kind load docker-image --name ${CLUSTER} python:3.11
+kind load docker-image --name ${CLUSTER} busybox
+kind load docker-image --name ${CLUSTER} metacontroller/jsonnetd:0.1

--- a/examples/secretpropagation/manifest/secret-propagation.yaml
+++ b/examples/secretpropagation/manifest/secret-propagation.yaml
@@ -38,7 +38,7 @@ spec:
     spec:
       containers:
       - name: controller
-        image: python:3.9
+        image: python:3.11
         command: ["python", "/hooks/sync.py"]
         volumeMounts:
         - name: hooks

--- a/examples/secretpropagation/manifest/sync.py
+++ b/examples/secretpropagation/manifest/sync.py
@@ -15,28 +15,28 @@
 # limitations under the License.
 
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import List
 import json
 import logging
-import typing
 
 logging.basicConfig(level=logging.DEBUG)
 LOGGER = logging.getLogger(__name__)
 
 
 class Controller(BaseHTTPRequestHandler):
-    def sync(self, parent: dict, related: dict) -> dict:
-        sourceNamespace: str = parent['spec']['sourceNamespace']
-        sourceName: str = parent['spec']['sourceName']
+    def sync(self, parent: dict, related: dict) -> List[dict]:
+        source_namespace: str = parent['spec']['sourceNamespace']
+        source_name: str = parent['spec']['sourceName']
         if len(related['Secret.v1']) == 0:
             LOGGER.info("Related resource has been deleted, clean-up copies")
             return []
-        original_secret: dict = related['Secret.v1'][f'{sourceNamespace}/{sourceName}']
-        targetNamespaces = related['Namespace.v1']
+        original_secret: dict = related['Secret.v1'][f'{source_namespace}/{source_name}']
+        target_namespaces = related['Namespace.v1']
         target_secrets = []
-        for namespace in targetNamespaces.values():
-            if namespace['metadata']['name'] != sourceNamespace:
+        for namespace in target_namespaces.values():
+            if namespace['metadata']['name'] != source_namespace:
                 target_secrets.append(self.new_secret(
-                    sourceName, namespace['metadata']['name'], original_secret['data']))
+                    source_name, namespace['metadata']['name'], original_secret['data']))
         return target_secrets
 
     def new_secret(self, name: str, namespace: str, data: dict) -> dict:
@@ -50,7 +50,7 @@ class Controller(BaseHTTPRequestHandler):
             'data': data
         }
 
-    def customize(self, sourceName: str, sourceNamespace: str, targetLabelSelector) -> dict:
+    def customize(self, sourceName: str, sourceNamespace: str, targetLabelSelector) -> List[dict]:
         return [
             {
                 'apiVersion': 'v1',

--- a/examples/secretpropagation/secret-propagation.yaml
+++ b/examples/secretpropagation/secret-propagation.yaml
@@ -106,7 +106,7 @@ spec:
     spec:
       containers:
       - name: controller
-        image: python:3.9
+        image: python:3.11
         command: ["python", "/hooks/sync.py"]
         volumeMounts:
         - name: hooks

--- a/examples/service-per-pod/my-statefulset.yaml
+++ b/examples/service-per-pod/my-statefulset.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 1
       containers:
       - name: nginx
-        image: gcr.io/google_containers/nginx-slim:0.8
+        image: nginx:1.26.2
         ports:
         - containerPort: 80
           name: web


### PR DESCRIPTION
Updated python version as well as python example code to use python 3.11.

Updated nginx image to use version 1.26.2.

Converted python2 code to python3.

Added examples/kind-load-images.sh utility script that will load the container images used in the examples to a running kind cluster.