### PR TITLE
fix: optimize cpu usage on claiming children

### DIFF
--- a/pkg/controller/composite/controller.go
+++ b/pkg/controller/composite/controller.go
@@ -44,6 +44,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
@@ -774,14 +775,44 @@ func (pc *parentController) claimChildren(parent *unstructured.Unstructured) (co
 		if informer == nil {
 			return nil, fmt.Errorf("no informer for resource %q in apiVersion %q", child.Resource, child.APIVersion)
 		}
-		var all []*unstructured.Unstructured
+
+		namespace := ""
 		if pc.parentResource.Namespaced {
-			all, err = informer.Lister().Namespace(parentNamespace).List(labels.Everything())
-		} else {
-			all, err = informer.Lister().List(labels.Everything())
+			namespace = parentNamespace
 		}
+
+		// Build the candidate set from two O(k) indexed lookups instead of an
+		// O(n) full-cache scan:
+		//
+		//  1. Already-owned children (OwnerUID index) — needed regardless of
+		//     selector match, because a drifted child must still be released.
+		//  2. Orphans which do not belong to any parent —
+		//     the only objects that could be adopted; objects owned by a different
+		//     controller are not adoption candidates and never need to be visited.
+		//
+		// This completely avoids iterating over children that belong to other
+		// parents, which is the dominant population in a busy cluster.
+		ownedByParent, err := informer.ListByOwnerUID(parent.GetUID(), namespace)
 		if err != nil {
-			return nil, fmt.Errorf("can't list %v children: %w", childClient.Kind, err)
+			return nil, fmt.Errorf("can't list owned %v children: %w", childClient.Kind, err)
+		}
+
+		orphans, err := informer.ListOrphans(namespace)
+		if err != nil {
+			return nil, fmt.Errorf("can't list orphan %v children: %w", childClient.Kind, err)
+		}
+		// Merge owned + orphans, deduplicating by UID (an object cannot be both,
+		// but guard against any edge case).
+		seen := make(map[types.UID]struct{}, len(ownedByParent)+len(orphans))
+		all := make([]*unstructured.Unstructured, 0, len(ownedByParent)+len(orphans))
+		for _, list := range [...][]*unstructured.Unstructured{ownedByParent, orphans} {
+			for _, obj := range list {
+				uid := obj.GetUID()
+				if _, dup := seen[uid]; !dup {
+					seen[uid] = struct{}{}
+					all = append(all, obj)
+				}
+			}
 		}
 
 		// Always include the requested groups, even if there are no entries.

--- a/pkg/dynamic/informer/informer.go
+++ b/pkg/dynamic/informer/informer.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 
@@ -35,6 +36,56 @@ import (
 
 	"k8s.io/client-go/dynamic/dynamiclister"
 )
+
+// orphanIndexSentinel is the fixed key under which all controller-ownerless
+// objects are stored in the OrphanIndex.
+const orphanIndexSentinel = "true"
+
+// OwnerUIDIndex is the name of the informer index that maps controller-owner
+// UID → owned objects. It is registered for every child-resource informer so
+// that claimChildren can retrieve already-owned objects in O(k) instead of
+// scanning the whole cache.
+const OwnerUIDIndex = "ownerUID"
+
+// ownerUIDIndexFunc returns the controller-owner UIDs for an object (i.e. the
+// UID of every owner reference where Controller==true).
+func ownerUIDIndexFunc(obj interface{}) ([]string, error) {
+	object, ok := obj.(metav1.Object)
+	if !ok {
+		return nil, nil
+	}
+	var uids []string
+	for _, ref := range object.GetOwnerReferences() {
+		if ref.Controller != nil && *ref.Controller {
+			uids = append(uids, string(ref.UID))
+		}
+	}
+	return uids, nil
+}
+
+// OrphanIndex is the name of the informer index that contains all objects that
+// have no controller owner reference. All such objects are stored under the
+// single key orphanIndexSentinel ("true").
+//
+// Indexing orphans allows claimChildren to limit its adoption scan to the
+// (typically small) orphan set, rather than scanning the full object cache.
+const OrphanIndex = "orphan"
+
+// orphanIndexFunc returns [orphanIndexSentinel] if the object has no
+// controller owner, so it appears in the OrphanIndex.
+func orphanIndexFunc(obj interface{}) ([]string, error) {
+	object, ok := obj.(metav1.Object)
+	if !ok {
+		return nil, nil
+	}
+	for _, ref := range object.GetOwnerReferences() {
+		if ref.Controller != nil && *ref.Controller {
+			// Has a controller owner — not an orphan.
+			return nil, nil
+		}
+	}
+	return []string{orphanIndexSentinel}, nil
+}
 
 // SharedIndexInformer is an extension of the standard interface of the same
 // name, adding the ability to remove event handlers that you added.
@@ -89,6 +140,48 @@ func (ri *ResourceInformer) Lister() dynamiclister.Lister {
 	return ri.sharedResourceInformer.lister
 }
 
+// ListByOwnerUID returns all cached objects whose controller-owner UID equals
+// the given uid. It uses the OwnerUIDIndex for an O(k) lookup instead of a
+// full cache scan, where k is the number of objects owned by that controller.
+//
+// We require filtering by namespace as well, since the same UID could be reused in different
+// namespaces and we don't want to return objects from other namespaces, to prevent possible
+// security issues.
+func (ri *ResourceInformer) ListByOwnerUID(uid types.UID, namespace string) ([]*unstructured.Unstructured, error) {
+	return ri.byIndexAndNamespace(OwnerUIDIndex, string(uid), namespace)
+}
+
+// ListOrphans returns cached objects that have no controller owner reference
+// and that match the given namespace and label selector.
+//
+// It uses the OrphanIndex for an O(k_orphan) lookup — only orphaned objects
+// are examined, not the full cache. namespace may be empty to match all
+// namespaces.
+func (ri *ResourceInformer) ListOrphans(namespace string) ([]*unstructured.Unstructured, error) {
+	return ri.byIndexAndNamespace(OrphanIndex, orphanIndexSentinel, namespace)
+}
+
+// byIndex is a shared helper that retrieves unstructured objects from a named
+// index by key.
+func (ri *ResourceInformer) byIndexAndNamespace(indexName, key string, namespace string) ([]*unstructured.Unstructured, error) {
+	items, err := ri.sharedResourceInformer.informer.GetIndexer().ByIndex(indexName, key)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*unstructured.Unstructured, 0, len(items))
+	for _, item := range items {
+		u, ok := item.(*unstructured.Unstructured)
+		if !ok {
+			continue
+		}
+		if namespace != "" && u.GetNamespace() != namespace {
+			continue
+		}
+		result = append(result, u)
+	}
+	return result, nil
+}
+
 // Close marks this ResourceInformer as unused, allowing the underlying shared
 // informer to be stopped when no users are left.
 // You should call this when you no longer need the informer, so the watches
@@ -129,6 +222,8 @@ func newSharedResourceInformer(client *dynamicclientset.ResourceClient, defaultR
 		defaultResyncPeriod,
 		cache.Indexers{
 			cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+			OwnerUIDIndex:        ownerUIDIndexFunc,
+			OrphanIndex:          orphanIndexFunc,
 		},
 	)
 	sri := &sharedResourceInformer{

--- a/test/integration/composite/composite_test.go
+++ b/test/integration/composite/composite_test.go
@@ -21,6 +21,7 @@ import (
 	customizeV1 "metacontroller/pkg/controller/common/customize/api/v1"
 	v1 "metacontroller/pkg/controller/composite/api/v1"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -397,5 +398,144 @@ func TestFailIfNoStatusSubresourceInParentCRD(t *testing.T) {
 	})
 	if err != nil {
 		t.Errorf("didn't find expected event: %v", err)
+	}
+}
+
+// TestClaimAndOrphanChildren verifies the two halves of the child-ownership
+// lifecycle that rely on the OwnerUID and Orphan informer indexes:
+//
+//  1. Adoption – a pre-existing orphan whose labels match the parent's selector
+//     gets its ownerReference set by the controller (claimed).
+//
+//  2. Release – once the child's labels no longer match the parent selector the
+//     controller removes the ownerReference (orphaned again).
+func TestClaimAndOrphanChildren(t *testing.T) {
+	ns := "test-claim-orphan-children"
+	matchingLabels := map[string]string{"test": "test-claim-orphan-children"}
+	nonMatchingLabels := map[string]string{"test": "no-match"}
+	childName := "pre-existing-child"
+
+	f := framework.NewFixture(t)
+	defer f.TearDown()
+
+	f.CreateNamespace(ns)
+	parentCRD, parentClient := f.CreateCRD("TestClaimOrphanParent", apiextensions.NamespaceScoped)
+	childCRD, childClient := f.CreateCRD("TestClaimOrphanChild", apiextensions.NamespaceScoped)
+
+	// releaseMode controls whether the sync hook returns children.
+	// While false the hook echoes the child back so manageChildren keeps it.
+	// While true the hook returns nothing, letting the controller release it.
+	var releaseMode atomic.Bool
+
+	hook := f.ServeWebhook(func(body []byte) ([]byte, error) {
+		req := v1.CompositeHookRequest{}
+		if err := json.Unmarshal(body, &req); err != nil {
+			return nil, err
+		}
+		resp := v1.CompositeHookResponse{}
+		if !releaseMode.Load() {
+			// Return the child as desired so manageChildren keeps it alive.
+			child := framework.UnstructuredCRD(childCRD, childName)
+			child.SetLabels(matchingLabels)
+			resp.Children = []*unstructured.Unstructured{child}
+		}
+		// When releaseMode is true we return no desired children, which allows
+		// manageChildren to leave the (now-ownerless) orphan alone.
+		return json.Marshal(resp)
+	})
+
+	f.CreateCompositeController(
+		"test-claim-orphan-children",
+		hook.URL, "",
+		framework.CRDResourceRule(parentCRD),
+		framework.CRDResourceRule(childCRD),
+		nil,
+	)
+
+	// --- Phase 1: pre-create an orphan child --------------------------------
+	//
+	// The child exists before the parent does. Its labels match the selector
+	// that the parent will declare, so the controller should adopt it.
+
+	orphan := framework.UnstructuredCRD(childCRD, childName)
+	orphan.SetLabels(matchingLabels)
+	orphan.SetNamespace(ns)
+	if _, err := childClient.Namespace(ns).Create(context.TODO(), orphan, metav1.CreateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create the parent and declare the matching label selector.
+	parent := framework.UnstructuredCRD(parentCRD, "test-claim-orphan-children")
+	unstructured.SetNestedStringMap(parent.Object, matchingLabels, "spec", "selector", "matchLabels")
+	if _, err := parentClient.Namespace(ns).Create(context.TODO(), parent, metav1.CreateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait until the orphan has been adopted: ownerReferences must contain an
+	// entry pointing at the parent.
+	t.Logf("Waiting for orphan child to be adopted (ownerReference set)...")
+	err := f.Wait(func() (bool, error) {
+		obj, err := childClient.Namespace(ns).Get(context.TODO(), childName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		for _, ref := range obj.GetOwnerReferences() {
+			if ref.Controller != nil && *ref.Controller {
+				t.Logf("Child adopted by %q (uid=%s)", ref.Name, ref.UID)
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("orphan child was never adopted: %v", err)
+	}
+
+	// --- Phase 2: release the child by changing its labels ------------------
+	//
+	// We update the child's labels so they no longer satisfy the parent's
+	// selector. The controller must detect this via the OwnerUID index
+	// (ListByOwnerUID), determine the selector no longer matches, and remove
+	// the ownerReference.
+
+	// Switch the hook to return no desired children before we break the labels,
+	// so that manageChildren does not re-create the child.
+	releaseMode.Store(true)
+
+	t.Logf("Updating child labels to break selector match; expecting controller to release it...")
+	err = f.Wait(func() (bool, error) {
+		obj, err := childClient.Namespace(ns).Get(context.TODO(), childName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		// Only patch if it still has an owner (idempotent retry-safe).
+		if len(obj.GetOwnerReferences()) == 0 {
+			return true, nil // already released on a previous iteration
+		}
+		obj.SetLabels(nonMatchingLabels)
+		if _, err := childClient.Namespace(ns).Update(context.TODO(), obj, metav1.UpdateOptions{}); err != nil {
+			return false, err // conflict → retry
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("could not update child labels: %v", err)
+	}
+
+	// Now wait for the controller to notice and strip the ownerReference.
+	t.Logf("Waiting for child to be released (ownerReference removed)...")
+	err = f.Wait(func() (bool, error) {
+		obj, err := childClient.Namespace(ns).Get(context.TODO(), childName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if len(obj.GetOwnerReferences()) == 0 {
+			t.Logf("Child has no ownerReferences – successfully released")
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Errorf("child was never released (ownerReference still present): %v", err)
 	}
 }


### PR DESCRIPTION
Fixes #1085

### Problem

`claimChildren` is called on every parent sync for every declared child resource type. The previous implementation called `List(labels.Everything())` on the informer lister, which internally calls `cache.ListAll` — a full iteration over **every** cached object of that type regardless of ownership. For a cluster-scoped parent with thousands of child objects across many parents this means:

- O(n) objects walked per parent per sync per child type
- CPU dominated by label matching on objects that can never be relevant to this specific parent

As an example: 1,000 parents × 10,000 children = **10 M label evaluations per resync wave**.

### Solution

Two informer indexes are registered on every child resource informer:

| Index | Key | Used for |
|---|---|---|
| `OwnerUIDIndex` | controller-owner UID | retrieve objects already owned by this parent — O(k_owned) |
| `OrphanIndex` | fixed sentinel `"true"` | retrieve all objects with no controller owner — O(k_orphan) |

`claimChildren` now builds its candidate set from exactly two indexed lookups:

1. **`ListByOwnerUID(parentUID)`** — objects already owned (must be visited to handle label drift → release)
2. **`ListOrphans(namespace)`** — ownerless objects (the only adoption candidates)

Objects owned by **other** controllers are never visited at all, which is the dominant population in a busy cluster.

### Complexity

| Step | Before | After |
|---|---|---|
| Candidate retrieval | O(n) full `ListAll` scan | O(k_owned) + O(k_orphan) |
| `ClaimChildren` loop | O(n) per parent | O(k_owned + k_orphan_match) per parent |
| Objects from other parents | fully iterated | never touched |
