### PR TITLE
fix(helm): deploy as Deployment

### DIFF
--- a/.github/workflows/test_release.yaml
+++ b/.github/workflows/test_release.yaml
@@ -144,7 +144,7 @@ jobs:
       - name: Apply metacontroller manifests
         run: |
           kubectl apply -k manifests/${{ matrix.configuration.variant }}
-          kubectl rollout status --watch --timeout=180s statefulset/metacontroller -n metacontroller || kubectl describe pod metacontroller-0 -n metacontroller
+          kubectl rollout status --watch --timeout=180s deployment/metacontroller -n metacontroller
           kubectl get pods -n metacontroller
 
       - name: Run e2e tests

--- a/deploy/helm/metacontroller/templates/deployments.yaml
+++ b/deploy/helm/metacontroller/templates/deployments.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: {{ include "metacontroller.fullname" . }}
   namespace: {{ include "metacontroller.namespace" . }}

--- a/examples/leader-election/manifest/args.yaml
+++ b/examples/leader-election/manifest/args.yaml
@@ -1,6 +1,6 @@
 # Override args for development mode.
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: metacontroller
   namespace: metacontroller

--- a/examples/leader-election/manifest/replicas.yaml
+++ b/examples/leader-election/manifest/replicas.yaml
@@ -1,6 +1,6 @@
 # Override args for development mode.
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: metacontroller
   namespace: metacontroller

--- a/examples/leader-election/test.sh
+++ b/examples/leader-election/test.sh
@@ -4,9 +4,9 @@ cleanup() {
   exit_code=$?
   set +e
   echo "Rollback metacontroller..."
-  kubectl scale statefulset --replicas="$previous_replicas" -n metacontroller metacontroller
-  kubectl rollout undo statefulset metacontroller -n metacontroller
-  kubectl rollout status --watch --timeout=180s statefulset/metacontroller -n metacontroller
+  kubectl scale deployment --replicas="$previous_replicas" -n metacontroller metacontroller
+  kubectl rollout undo deployment metacontroller -n metacontroller
+  kubectl rollout status --watch --timeout=180s deployment/metacontroller -n metacontroller
   exit $exit_code
 }
 trap cleanup EXIT
@@ -16,33 +16,37 @@ set -euo
 success_msg='Successfully acquired lease'
 attempt_msg='Attempting to acquire leader lease'
 
-previous_replicas=$(kubectl get statefulset metacontroller -n metacontroller -o=jsonpath='{.spec.replicas}')
+previous_replicas=$(kubectl get deployment metacontroller -n metacontroller -o=jsonpath='{.spec.replicas}')
 kubectl apply -k ./manifest
-kubectl rollout status --watch --timeout=180s statefulset/metacontroller -n metacontroller
+kubectl rollout status --watch --timeout=180s deployment/metacontroller -n metacontroller
 
 # both pods must be ready before checking logs
-kubectl wait --timeout=180s --for=condition=ready pod metacontroller-0 -n metacontroller
-kubectl wait --timeout=180s --for=condition=ready pod metacontroller-1 -n metacontroller
+kubectl wait --timeout=180s --for=condition=ready pod -l app.kubernetes.io/name=metacontroller -n metacontroller
+
+# get pod names dynamically (Deployments have random pod names)
+readarray -t pods < <(kubectl get pods -l app.kubernetes.io/name=metacontroller -n metacontroller -ojsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
+pod0="${pods[0]}"
+pod1="${pods[1]}"
 
 maximum_attempts=36
 # wait for one pod to acquire the leader lease
-until [[ "$(kubectl logs metacontroller-0 -n metacontroller | grep "$success_msg" | wc -l)" -eq 1 ||
-         "$(kubectl logs metacontroller-1 -n metacontroller | grep "$success_msg" | wc -l)" -eq 1 ]]; do
+until [[ "$(kubectl logs "$pod0" -n metacontroller | grep "$success_msg" | wc -l)" -eq 1 ||
+         "$(kubectl logs "$pod1" -n metacontroller | grep "$success_msg" | wc -l)" -eq 1 ]]; do
   sleep 5
   # timeout at 180s if no leader lease acquired
   ((maximum_attempts--)) # this will exit with an error when equal to zero
 done
 
 # determine which pods have attempted or successfully acquired the leader lease
-pod0_attempt=$(kubectl logs metacontroller-0 -n metacontroller | grep "$attempt_msg" | wc -l | xargs echo -n)
-pod0_success=$(kubectl logs metacontroller-0 -n metacontroller | grep "$success_msg" | wc -l | xargs echo -n)
-pod1_attempt=$(kubectl logs metacontroller-1 -n metacontroller | grep "$attempt_msg" | wc -l | xargs echo -n)
-pod1_success=$(kubectl logs metacontroller-1 -n metacontroller | grep "$success_msg" | wc -l | xargs echo -n)
+pod0_attempt=$(kubectl logs "$pod0" -n metacontroller | grep "$attempt_msg" | wc -l | xargs echo -n)
+pod0_success=$(kubectl logs "$pod0" -n metacontroller | grep "$success_msg" | wc -l | xargs echo -n)
+pod1_attempt=$(kubectl logs "$pod1" -n metacontroller | grep "$attempt_msg" | wc -l | xargs echo -n)
+pod1_success=$(kubectl logs "$pod1" -n metacontroller | grep "$success_msg" | wc -l | xargs echo -n)
 
 echo
 echo "Leader election results:"
-echo "metacontroller-0 leader election attempt count: $pod0_attempt, acquired count: $pod0_success"
-echo "metacontroller-1 leader election attempt count: $pod1_attempt, acquired count: $pod1_success"
+echo "$pod0 leader election attempt count: $pod0_attempt, acquired count: $pod0_success"
+echo "$pod1 leader election attempt count: $pod1_attempt, acquired count: $pod1_success"
 echo
 
 # only one pod should successfully acquire the leader lease

--- a/examples/pprof-profiling/README.md
+++ b/examples/pprof-profiling/README.md
@@ -29,7 +29,7 @@ Once disabled, the endpoint `/debug/pprof` will be unavailable.
   ```
 
 ### Profiling metacontroller
-- Port-forward metacontroller `kubectl -n metacontroller port-forward statefulset/metacontroller 6060`
+- Port-forward metacontroller `kubectl -n metacontroller port-forward deployment/metacontroller 6060`
 - Open http://localhost:6060/debug/pprof/ in a web browser
 - Select your desired profile.
 

--- a/examples/pprof-profiling/manifest/args.yaml
+++ b/examples/pprof-profiling/manifest/args.yaml
@@ -1,6 +1,6 @@
 # Override args for development mode.
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: metacontroller
   namespace: metacontroller

--- a/examples/pprof-profiling/test.sh
+++ b/examples/pprof-profiling/test.sh
@@ -4,8 +4,8 @@ cleanup() {
   exit_code=$?
   set +e
   echo "Rollback metacontroller..."
-  kubectl rollout undo statefulset metacontroller -n metacontroller
-  kubectl rollout status --watch --timeout=180s statefulset/metacontroller -n metacontroller
+  kubectl rollout undo deployment metacontroller -n metacontroller
+  kubectl rollout status --watch --timeout=180s deployment/metacontroller -n metacontroller
   kubectl delete -f manifest/service.yaml
   exit $exit_code
 }
@@ -25,7 +25,7 @@ set -euo
 
 echo "Enable pprof on metacontroller..."
 kubectl apply -k ./manifest
-kubectl rollout status --watch --timeout=180s statefulset/metacontroller -n metacontroller
+kubectl rollout status --watch --timeout=180s deployment/metacontroller -n metacontroller
 
 echo "Test profiling metacontroller..."
 sleep 2

--- a/examples/prometheus-monitoring/README.md
+++ b/examples/prometheus-monitoring/README.md
@@ -16,11 +16,11 @@ a [Prometheus](https://prometheus.io/) instance for monitoring metacontroller.
 ### Helm Installation
     helm install metacontoller deploy/helm/metacontroller -n metacontroller --create-namespace -f deploy/helm/metacontroller/ci/service-values.yaml
     kubectl apply -f examples/prometheus-monitoring/manifest/serviceMonitor.yaml
-    kubectl rollout status --watch --timeout=180s statefulset/metacontroller -n metacontroller
+    kubectl rollout status --watch --timeout=180s deployment/metacontroller -n metacontroller
 
 ### Kubectl Installation
     kubectl apply -k examples/prometheus-monitoring/manifest
-    kubectl rollout status --watch --timeout=180s statefulset/metacontroller -n metacontroller
+    kubectl rollout status --watch --timeout=180s deployment/metacontroller -n metacontroller
 
 ## Viewing metrics
 - port forward prometheus UI port to localhost 

--- a/examples/prometheus-monitoring/manifest/ports.yaml
+++ b/examples/prometheus-monitoring/manifest/ports.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: metacontroller
   namespace: metacontroller

--- a/examples/prometheus-monitoring/test.sh
+++ b/examples/prometheus-monitoring/test.sh
@@ -6,8 +6,8 @@ cleanup() {
   echo "Killing port-forward for prometheus..."
   pkill kubectl
   echo "Rollback metacontroller..."
-  kubectl rollout undo statefulset metacontroller -n metacontroller
-  kubectl rollout status --watch --timeout=180s statefulset/metacontroller -n metacontroller
+  kubectl rollout undo deployment metacontroller -n metacontroller
+  kubectl rollout status --watch --timeout=180s deployment/metacontroller -n metacontroller
   echo "Uninstall prometheus..."
   kubectl delete -f ./manifest/prometheus.yaml
   kubectl delete -k github.com/prometheus-operator/prometheus-operator?ref=v0.49.0
@@ -31,7 +31,7 @@ kubectl rollout status --watch --timeout=180s statefulset/prometheus-prometheus
 
 echo "Enable prometheus monitoring on metacontroller..."
 kubectl apply -k ./manifest
-kubectl rollout status --watch --timeout=180s statefulset/metacontroller -n metacontroller
+kubectl rollout status --watch --timeout=180s deployment/metacontroller -n metacontroller
 
 echo "Starting port-forward for prometheus..."
 kubectl port-forward statefulset/prometheus-prometheus 9090 &

--- a/examples/target-label-selector/instance/args.yaml
+++ b/examples/target-label-selector/instance/args.yaml
@@ -1,6 +1,6 @@
 # Override args for development mode.
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: metacontroller
   namespace: metacontroller

--- a/examples/target-label-selector/test.sh
+++ b/examples/target-label-selector/test.sh
@@ -9,8 +9,8 @@ cleanup() {
   kubectl delete -k ./manifest
 
   echo "Rollback metacontroller..."
-  kubectl rollout undo statefulset metacontroller -n metacontroller
-  kubectl rollout status --watch --timeout=180s statefulset/metacontroller -n metacontroller
+  kubectl rollout undo deployment metacontroller -n metacontroller
+  kubectl rollout status --watch --timeout=180s deployment/metacontroller -n metacontroller
   exit $exit_code
 }
 trap cleanup EXIT
@@ -19,10 +19,10 @@ set -euo
 
 # install metacontroller with the --target-label-selector arg.
 kubectl apply -k ./instance
-kubectl rollout status --watch --timeout=180s statefulset/metacontroller -n metacontroller
+kubectl rollout status --watch --timeout=180s deployment/metacontroller -n metacontroller
 
 # wait for metacontroller pod to be ready
-kubectl wait --timeout=180s --for=condition=ready pod metacontroller-0 -n metacontroller
+kubectl wait --timeout=180s --for=condition=ready pod -l app.kubernetes.io/name=metacontroller -n metacontroller
 
 # install the the secretpropagation example and applies a patch to add labels to the CompositeController instance.
 kubectl apply -k ./manifest

--- a/manifests/debug/args.yaml
+++ b/manifests/debug/args.yaml
@@ -1,6 +1,6 @@
 # Override args for development mode.
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: metacontroller
   namespace: metacontroller

--- a/manifests/debug/image.yaml
+++ b/manifests/debug/image.yaml
@@ -1,6 +1,6 @@
 # Override image for development mode (skaffold fills in the tag).
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: metacontroller
   namespace: metacontroller

--- a/manifests/debug/kustomization.yaml
+++ b/manifests/debug/kustomization.yaml
@@ -3,19 +3,19 @@ resources:
 patches:
 - target:
     group: apps
-    kind: StatefulSet
+    kind: Deployment
     version: v1
     name: metacontroller
   path: args.yaml
 - target:
     group: apps
-    kind: StatefulSet
+    kind: Deployment
     version: v1
     name: metacontroller
   path: image.yaml
 - target:
     group: apps
-    kind: StatefulSet
+    kind: Deployment
     version: v1
     name: metacontroller
   patch: |-

--- a/manifests/dev-ssa/args.yaml
+++ b/manifests/dev-ssa/args.yaml
@@ -1,6 +1,6 @@
 # Override args for development mode.
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: metacontroller
   namespace: metacontroller

--- a/manifests/dev-ssa/image.yaml
+++ b/manifests/dev-ssa/image.yaml
@@ -1,6 +1,6 @@
 # Override image for development mode (skaffold fills in the tag).
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: metacontroller
   namespace: metacontroller

--- a/manifests/dev/args.yaml
+++ b/manifests/dev/args.yaml
@@ -1,6 +1,6 @@
 # Override args for development mode.
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: metacontroller
   namespace: metacontroller

--- a/manifests/dev/image.yaml
+++ b/manifests/dev/image.yaml
@@ -1,6 +1,6 @@
 # Override image for development mode (skaffold fills in the tag).
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: metacontroller
   namespace: metacontroller

--- a/manifests/production/metacontroller.yaml
+++ b/manifests/production/metacontroller.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: metacontroller
@@ -11,7 +11,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: metacontroller
-  serviceName: ""
   template:
     metadata:
       labels:
@@ -33,4 +32,3 @@ spec:
           httpGet:
             port: 8081
             path: /readyz
-  volumeClaimTemplates: []

--- a/test/integration/framework/main.go
+++ b/test/integration/framework/main.go
@@ -158,7 +158,7 @@ func testMain(tests func() int, configuration options.Configuration) error {
 	}
 
 	// In this integration test environment, there are no Nodes, so the
-	// metacontroller StatefulSet will not actually run anything.
+	// metacontroller Deployment will not actually run anything.
 	// Instead, we start the Metacontroller server locally inside the test binary,
 	// since that's part of the code under test.
 	port, err := getAvailablePort()


### PR DESCRIPTION
Metacontroller is stateless, so no need to deploy as a StatefulSet.

This way, the scheduler has more flexibility.

@moduon MT-14138
