### PR TITLE
fix(hooks): log invalid webhook configuration instead of failing silently

### DIFF
--- a/pkg/hooks/webhook.go
+++ b/pkg/hooks/webhook.go
@@ -70,6 +70,7 @@ func NewWebhookExecutor(
 	}
 	url, err := webhookURL(webhook)
 	if err != nil {
+		logging.Logger.Error(err, "invalid webhook configuration; check the hook url/service/path", "controller", controllerName, "hookType", hookType)
 		return nil, err
 	}
 	hookTimeout, err := webhookTimeout(webhook)

--- a/pkg/hooks/webhook.go
+++ b/pkg/hooks/webhook.go
@@ -70,7 +70,7 @@ func NewWebhookExecutor(
 	}
 	url, err := webhookURL(webhook)
 	if err != nil {
-		logging.Logger.Error(err, "invalid webhook configuration; check the hook url/service/path", "controller", controllerName, "hookType", hookType)
+		logging.Logger.Error(err, "invalid webhook configuration", "controller", controllerName, "hookType", hookType)
 		return nil, err
 	}
 	hookTimeout, err := webhookTimeout(webhook)
@@ -278,13 +278,13 @@ func webhookURL(webhook *v1alpha1.Webhook) (string, error) {
 		return *webhook.URL, nil
 	}
 	if webhook.Service == nil || webhook.Path == nil {
-		return "", fmt.Errorf("invalid webhook config: must specify either full 'url', or both 'service' and 'path'")
+		return "", fmt.Errorf("invalid webhook config: must specify either a full 'url', or both 'service' and 'path'")
 	}
 
 	// For now, just use cluster DNS to resolve Services.
 	// If necessary, we can use a Lister to get more info about Services.
 	if webhook.Service.Name == "" || webhook.Service.Namespace == "" {
-		return "", fmt.Errorf("invalid client config: must specify service 'name' and 'namespace'")
+		return "", fmt.Errorf("invalid webhook config: 'service' must specify both 'name' and 'namespace'")
 	}
 	port := int32(80)
 	if webhook.Service.Port != nil {

--- a/pkg/hooks/webhook_test.go
+++ b/pkg/hooks/webhook_test.go
@@ -444,11 +444,28 @@ func mustParsePEMBlock(t *testing.T, data []byte) *pem.Block {
 
 // TestNewWebhookExecutor_InvalidConfig verifies that a webhook with neither a
 // full URL nor both service and path fails construction with a clear error
-// rather than silently producing an unusable executor.
+// rather than silently producing an unusable executor. It also checks that
+// each distinct misconfiguration produces a specific message so operators
+// are not misdirected by a single generic hint.
 func TestNewWebhookExecutor_InvalidConfig(t *testing.T) {
-	webhook := &v1alpha1.Webhook{} // no URL, no Service, no Path
-	executor, err := NewWebhookExecutor(webhook, nil, "test-controller", common.CompositeController, common.SyncHook, nil)
-	require.Error(t, err)
-	assert.Nil(t, executor)
-	assert.Contains(t, err.Error(), "invalid webhook config")
+	t.Run("missing url and service/path", func(t *testing.T) {
+		webhook := &v1alpha1.Webhook{} // no URL, no Service, no Path
+		executor, err := NewWebhookExecutor(webhook, nil, "test-controller", common.CompositeController, common.SyncHook, nil)
+		require.Error(t, err)
+		assert.Nil(t, executor)
+		assert.Contains(t, err.Error(), "invalid webhook config")
+	})
+
+	t.Run("service missing name/namespace", func(t *testing.T) {
+		webhook := &v1alpha1.Webhook{
+			Service: &v1alpha1.ServiceReference{},
+			Path:    ptr.To[string]("/hook"),
+		}
+		executor, err := NewWebhookExecutor(webhook, nil, "test-controller", common.CompositeController, common.SyncHook, nil)
+		require.Error(t, err)
+		assert.Nil(t, executor)
+		assert.Contains(t, err.Error(), "invalid webhook config")
+		assert.Contains(t, err.Error(), "name")
+		assert.Contains(t, err.Error(), "namespace")
+	})
 }

--- a/pkg/hooks/webhook_test.go
+++ b/pkg/hooks/webhook_test.go
@@ -441,3 +441,14 @@ func mustParsePEMBlock(t *testing.T, data []byte) *pem.Block {
 	require.NotNil(t, block, "no PEM block found")
 	return block
 }
+
+// TestNewWebhookExecutor_InvalidConfig verifies that a webhook with neither a
+// full URL nor both service and path fails construction with a clear error
+// rather than silently producing an unusable executor.
+func TestNewWebhookExecutor_InvalidConfig(t *testing.T) {
+	webhook := &v1alpha1.Webhook{} // no URL, no Service, no Path
+	executor, err := NewWebhookExecutor(webhook, nil, "test-controller", common.CompositeController, common.SyncHook, nil)
+	require.Error(t, err)
+	assert.Nil(t, executor)
+	assert.Contains(t, err.Error(), "invalid webhook config")
+}


### PR DESCRIPTION
When a hook specifies neither a full url nor both service and path, NewWebhookExecutor returned the error without logging it, so a typo'd or missing webhook url produced no operator-visible signal. The error is now logged with the controller and hook type so the misconfiguration is surfaced.