### PR TITLE
fix: allow resync events through ignoreStatusChanges filter

### DIFF
--- a/pkg/controller/composite/controller.go
+++ b/pkg/controller/composite/controller.go
@@ -417,7 +417,11 @@ func (pc *parentController) updateParentObject(old, cur interface{}) {
 				// if ignoreStatusChanges is set to true in the composite controller, a parent object should only be
 				// enqueued if there is a change in the generation or if there is a change in its labels/annotations,
 				// or if there is a deletion timestamp attached to the object, otherwise it will be ignored.
-				if parentOld.GetGeneration() == parentCur.GetGeneration() {
+				// However, a resync event passes the same pointer for both old and cur (eh.resync()), so we must
+				// allow it through to avoid silently dropping periodic reconciles.
+				if parentOld == parentCur {
+					// resync event — pass through
+				} else if parentOld.GetGeneration() == parentCur.GetGeneration() {
 					if reflect.DeepEqual(parentOld.GetLabels(), parentCur.GetLabels()) &&
 						reflect.DeepEqual(parentOld.GetAnnotations(), parentCur.GetAnnotations()) &&
 						parentCur.GetDeletionTimestamp() == nil {

--- a/pkg/controller/decorator/controller.go
+++ b/pkg/controller/decorator/controller.go
@@ -425,9 +425,13 @@ func (c *decoratorController) updateParentObject(old, cur interface{}) {
 				// if ignoreStatusChanges is set to true in the decorator controller, a parent object should only be
 				// enqueued if there is a change in the generation or if there is a change in its labels/annotations,
 				// or if there is a deletion timestamp attached to the object, otherwise it will be ignored.
+				// However, a resync event passes the same pointer for both old and cur (eh.resync()), so we must
+				// allow it through to avoid silently dropping periodic reconciles.
 				if parent.IgnoreStatusChanges != nil && *parent.IgnoreStatusChanges {
 					if parentCur, ok := cur.(*unstructured.Unstructured); ok {
-						if parentOld.GetGeneration() == parentCur.GetGeneration() {
+						if parentOld == parentCur {
+							// resync event — pass through
+						} else if parentOld.GetGeneration() == parentCur.GetGeneration() {
 							if reflect.DeepEqual(parentOld.GetLabels(), parentCur.GetLabels()) &&
 								reflect.DeepEqual(parentOld.GetAnnotations(), parentCur.GetAnnotations()) &&
 								parentCur.GetDeletionTimestamp() == nil {


### PR DESCRIPTION
When ignoreStatusChanges is true, updateParentObject drops events where old and cur have the same generation, labels, annotations and no deletion timestamp. A resync event passes the same pointer for both old and cur (from eh.resync()), so it always matched this filter and was silently dropped.

This means periodic reconciles configured via resyncPeriodSeconds never fire when ignoreStatusChanges is set. Users have to fall back to resyncAfterSeconds in webhook responses as a workaround.

Fix: distinguish resync events by pointer equality (old == cur) and let them through to the workqueue.

Fixes #1136